### PR TITLE
feat(User) : google login 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     compileOnly 'org.projectlombok:lombok'
 
@@ -33,6 +34,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/src/main/java/com/zerobase/wishmarket/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/wishmarket/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .headers().frameOptions().disable()
                 .and()
                     .authorizeRequests()
-                    .antMatchers("/api/**").hasRole("USER")
+                    .antMatchers("/api/**").permitAll()
                 .and()
                     // logout 요청시 홈으로 이동 - 기본 logout url = "/logout"
                     .logout().logoutSuccessUrl("/")

--- a/src/main/java/com/zerobase/wishmarket/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/wishmarket/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.zerobase.wishmarket.config;
+
+
+import com.zerobase.wishmarket.domain.user.service.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    private final OAuthService oAuthService;
+
+    @Deprecated
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                // h2-console 사용을 위한 옵션 disable
+                .csrf().disable()
+                .headers().frameOptions().disable()
+                .and()
+                    .authorizeRequests()
+                    .antMatchers("/api/**").hasRole("USER")
+                .and()
+                    // logout 요청시 홈으로 이동 - 기본 logout url = "/logout"
+                    .logout().logoutSuccessUrl("/")
+                .and()
+                    // OAuth2 로그인 설정 시작점
+                    .oauth2Login()
+                    // OAuth2 로그인 성공 이후 사용자 정보를 가져올 때 설정 담당
+                    .userInfoEndpoint()
+                    // OAuth2 로그인 성공 시, 작업을 진행할 MemberService
+                    .userService(oAuthService);
+    }
+}
+

--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/AuthController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.zerobase.wishmarket.domain.user.controller;
+
+import com.zerobase.wishmarket.domain.user.model.dto.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final HttpSession httpSession;
+
+    @GetMapping("/social-sign-in")
+    public String oauthLoginInfo(Model model) {
+
+        OAuthUserInfo user = (OAuthUserInfo) httpSession.getAttribute("user");
+        if (user != null) {
+            model.addAttribute("userName", user.getName());
+        }
+
+        return "oauthLoginInfo";
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/OAuthUserInfo.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/OAuthUserInfo.java
@@ -1,0 +1,22 @@
+package com.zerobase.wishmarket.domain.user.model.dto;
+
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+public class OAuthUserInfo implements Serializable {
+
+    private Long userId;
+    private String name;
+    private String email;
+    private String profileImage;
+
+    public OAuthUserInfo(UserEntity userEntity) {
+        this.userId = userEntity.getUserId();
+        this.name = userEntity.getName();
+        this.email = userEntity.getEmail();
+        this.profileImage = userEntity.getProfileImage();
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
@@ -57,8 +57,13 @@ public class UserEntity extends BaseEntity {
     private UserStatus userStatus;
 
     // 1 : 1 Mapping
-
     // 주소
     @OneToOne(mappedBy = "userEntity", fetch = FetchType.LAZY)
     private DeliveryAddress deliveryAddress;
+
+    public UserEntity update(String name, String profileImage) {
+        this.name = name;
+        this.profileImage = profileImage;
+        return this;
+    }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/type/OAuthAttributes.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/type/OAuthAttributes.java
@@ -34,7 +34,7 @@ public class OAuthAttributes {
         return OAuthAttributes.builder()
                 .name((String) attributes.get("name"))
                 .email((String) attributes.get("email"))
-                .profileImage((String) attributes.get("profileImage"))
+                .profileImage((String) attributes.get("picture"))
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
                 .build();

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/type/OAuthAttributes.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/type/OAuthAttributes.java
@@ -1,0 +1,53 @@
+package com.zerobase.wishmarket.domain.user.model.type;
+
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String profileImage;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String profileImage) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.profileImage = profileImage;
+    }
+
+    // 반환하는 사용자 정보는 Map
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .profileImage((String) attributes.get("profileImage"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    // User Entity 생성
+    // 엔터티 생성시점 : 처음 가입 및 로그인(소셜 계정)할 때
+    public UserEntity toEntity() {
+        return UserEntity.builder()
+                .name(name)
+                .email(email)
+                .profileImage(profileImage)
+                .userRole(UserRoles.USER)
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
@@ -3,6 +3,9 @@ package com.zerobase.wishmarket.domain.user.repository;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
+    Optional<UserEntity> findByEmail(String email);
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/OAuthService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/OAuthService.java
@@ -1,0 +1,57 @@
+package com.zerobase.wishmarket.domain.user.service;
+
+import com.zerobase.wishmarket.domain.user.model.dto.OAuthUserInfo;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.OAuthAttributes;
+import com.zerobase.wishmarket.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // 현재 로그인 진행중인 서비스를 구분 (추후 네이버 등 연동 시 구분 필요)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                // 키가 되는 필드값 (Primary Key와 같은 의미)
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        UserEntity userEntity = saveOrUpdate(attributes);
+        // 세션에 사용자 정보를 저장하기 위한 Dto 클래스 : SessionUser
+        httpSession.setAttribute("user", new OAuthUserInfo(userEntity));
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("USER")),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey());
+    }
+
+    private UserEntity saveOrUpdate(OAuthAttributes attributes) {
+        UserEntity userEntity = userRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName(), attributes.getProfileImage()))
+                .orElse(attributes.toEntity());
+
+        return userRepository.save(userEntity);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,8 @@ spring.jpa.hibernate.ddl-auto=create
 #Swagger
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
-
+# OAuth
+spring.profiles.include=oauth
 
 
 

--- a/src/test/java/com/zerobase/wishmarket/domain/auth/OAuthLoginTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/auth/OAuthLoginTest.java
@@ -1,0 +1,38 @@
+package com.zerobase.wishmarket.domain.auth;
+
+import com.zerobase.wishmarket.domain.user.controller.AuthController;
+import com.zerobase.wishmarket.domain.user.service.OAuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.MockBeans;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@MockBeans({
+        @MockBean(JpaMetamodelMappingContext.class),
+        @MockBean(OAuthService.class)
+})
+public class OAuthLoginTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    private SecurityMockMvcRequestPostProcessors securityMockMvcRequestPostProcessors;
+
+    @Test
+    void googleLoginTest() throws Exception {
+
+        mvc.perform(post("/social-sign-in").with(oauth2Login()))
+                .andExpect(status().isOk());
+
+    }
+}


### PR DESCRIPTION
## 관련이슈
-  #8 

## 변경사항

- OAuth 의존성 추가
- OAuth client 정보 : application-oauth.properties 파일에서 관리 -> 깃허브 미반영
- 관련 클래스 생성
- postman 테스트 : Access Token 발급 완료 확인
<br>

## 추후 보완 적용 예정사항

- 현재 구현한 방식으로는 아래의 코드처럼 로그인한 유저의 정보를 세션(OAuthUserInfo)에 담아두고 있습니다. 
- `OAuthUserInfo user = (OAuthUserInfo) httpSession.getAttribute("user");`
- 메인 페이지뿐만 아니라 앞으로 구현될 여러 컨트롤러와 메소드에서 세션값이 필요하면 직접 세션을 가져와야 합니다. 따라서 이 부분을 메소드 인자로 세션값을 바로 받을 수 있도록 수정할 계획입니다.
- 계획은 LoginUser 라는 인터페이스를 구성하여 어노테이션 클래스로 지정하고 @LoginUser 라는 어노테이션을 사용하면 세션 정보를 가져올 수 있도록 변경할 예정입니다. 

## 체크 리스트 (Checklist)

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?

## 테스트 결과

**1. API 호출 시, 등록해놓은 WishMarket-webservice 를 통해 구글 로그인에 접근한 상태입니다.**
<img width="527" alt="스크린샷 2023-02-10 오전 12 05 39" src="https://user-images.githubusercontent.com/113086103/217875997-3d849879-8e05-4408-a2af-c7d1d923c231.png">


**2. Postman에서 API 호출 시 Access Token 을 정상적으로 받아온 결과입니다.**
<img width="795" alt="스크린샷 2023-02-09 오후 9 52 22" src="https://user-images.githubusercontent.com/113086103/217875551-7c86b440-0063-4a10-bb41-58312be63e9f.png">


**3. Mustache를 통해 직접 실행 후 테스트한 결과입니다. 로그인 시 사용한 계정에 등록되어 있는 유저의 이름을 출력합니다.**
![스크린샷 2023-02-10 오전 1 14 30](https://user-images.githubusercontent.com/113086103/217876453-55dad554-618f-499f-819a-73348c2e58b7.png)
![스크린샷 2023-02-10 오전 1 14 43](https://user-images.githubusercontent.com/113086103/217876857-cfe7a5cd-2269-442a-b993-d119871575d3.png)


**4. h2-console 을 통해 입력된 유저의 정보를 확인한 결과입니다. 이메일 주소, 이름, 프로필 이미지 경로, 유저 권한을 Entity 생성 시 반영합니다.**
![스크린샷 2023-02-10 오전 1 15 24](https://user-images.githubusercontent.com/113086103/217877361-718436c2-d67b-4454-9d24-828d59c50dfd.png)


