### PR TITLE
feat(User) : naver 로그인 구현

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/domain/user/config/LoginUserArgumentResolver.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/config/LoginUserArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.zerobase.wishmarket.domain.user.config;
+
+import com.zerobase.wishmarket.domain.user.model.dto.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final HttpSession httpSession;
+
+    @Override
+    // supportsParameter() : 컨트롤러 메소드의 특정 파라미터 지원 여부 판단
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isLoginUserAnnotation = parameter.getParameterAnnotation(LoginUserInfo.class) != null;
+        boolean isUserClass = OAuthUserInfo.class.equals(parameter.getParameterType());
+        return isLoginUserAnnotation && isUserClass;
+    }
+
+
+    @Override
+    // resolveArgument() : 세션에서 객체를 가져와서 파라미터에 전달할 객체 생성
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return httpSession.getAttribute("user");
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/config/LoginUserInfo.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/config/LoginUserInfo.java
@@ -1,0 +1,14 @@
+package com.zerobase.wishmarket.domain.user.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+// @Target : 어노테이션 생성 위치 지정 - 메소드의 파라미터로 선언된 객체에서만 사용 가능
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+// 어노테이션 클래스 지정 -> @LoginUserInfo 생성
+public @interface LoginUserInfo {
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/config/WebConfig.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.zerobase.wishmarket.domain.user.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    // HandlerMethodArgumentResolver : 항상 WebMvcConfigurer 의 addArgumentResolvers() 메소드를 통해 추가해야함
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.zerobase.wishmarket.domain.user.controller;
 
+import com.zerobase.wishmarket.domain.user.config.LoginUserInfo;
 import com.zerobase.wishmarket.domain.user.model.dto.OAuthUserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ui.Model;
@@ -12,14 +13,13 @@ import javax.servlet.http.HttpSession;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/auth")
-public class AuthController {
-
-    private final HttpSession httpSession;
+public class UserController {
 
     @GetMapping("/social-sign-in")
-    public String oauthLoginInfo(Model model) {
+    // 기존 : httpSession.getAttribute 로 가져오던 세션 정보
+    // 수정 : 어느 컨트롤러에서든 @LoginUserInfo 를 사용하여 세션 정보 활용 가능
+    public String oauthLoginInfo(Model model, @LoginUserInfo OAuthUserInfo user) {
 
-        OAuthUserInfo user = (OAuthUserInfo) httpSession.getAttribute("user");
         if (user != null) {
             model.addAttribute("userName", user.getName());
         }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/type/OAuthAttributes.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/type/OAuthAttributes.java
@@ -13,18 +13,24 @@ public class OAuthAttributes {
     private String name;
     private String email;
     private String profileImage;
+    private String userRegistration;
 
     @Builder
-    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String profileImage) {
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String profileImage, String userRegistration) {
         this.attributes = attributes;
         this.nameAttributeKey = nameAttributeKey;
         this.name = name;
         this.email = email;
         this.profileImage = profileImage;
+        this.userRegistration = userRegistration;
     }
 
     // 반환하는 사용자 정보는 Map
     public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+
+        if("naver".equals(registrationId)) {
+            return ofNaver("id", attributes);
+        }
 
         return ofGoogle(userNameAttributeName, attributes);
     }
@@ -35,7 +41,21 @@ public class OAuthAttributes {
                 .name((String) attributes.get("name"))
                 .email((String) attributes.get("email"))
                 .profileImage((String) attributes.get("picture"))
+                .userRegistration(String.valueOf(UserRegistration.GOOGLE))
                 .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuthAttributes.builder()
+                .name((String) response.get("name"))
+                .email((String) response.get("email"))
+                .profileImage((String) response.get("picture"))
+                .userRegistration(String.valueOf(UserRegistration.NAVER))
+                .attributes(response)
                 .nameAttributeKey(userNameAttributeName)
                 .build();
     }


### PR DESCRIPTION
## 관련이슈
-  #17 

## 변경사항

- 기존 httpSession 으로 사용하던 세션값 호출 방식-> (OAuthUserInfo) httpSession.getAttribute("user")
- 수정 : 어노테이션 클래스 등록으로 어느 컨트롤러, 메소드에서든 @LoginUserInfo 를 사용하여 세션 정보 활용 가능
- 네이버 로그인 구현

## 추후 보완 적용 예정사항

- 현재는 구글 로그인과 네이버 로그인 시 작동하는 메소드의 구분까지는 되어있으나, User Entity 생성 시점에 UserRegistration Enum Type이 구분되어 들어가지 않고 있습니다.
- 메소드별 Enum Type을 설정하여 전달하는 부분까지는 확인했고, 소셜의 타입에 따라 해당 Enum Type을 구분하여 반영되도록 추가할 예정입니다.
- 네이버와 구글에서 받아올 수 있는 정보가 달라 일단 공통으로 적용할 수 있는 부분까지는 반영했습니다. 필수 활용 정보와 추가 정보를 활용할 방안을 구체화 한 뒤 해당 내용을 반영할 예정입니다.

## 체크 리스트 (Checklist)

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?

## 테스트 결과

**1. Mustache를 통해 직접 실행 후 테스트한 결과입니다. 필수정보(이름, 닉네임, 이메일)와 선택정보(연락처, 프로필 이미지)를 구분해두었습니다.**
![스크린샷 2023-02-10 오후 7 49 45](https://user-images.githubusercontent.com/113086103/218077360-d5a5ed1f-2b64-4336-9f6a-d0a627a37c82.png)


**2. h2-console로 구글 로그인, 네이버 로그인을 진행한 뒤 데이터가 입력된 결과입니다.**
![스크린샷 2023-02-10 오후 7 50 58](https://user-images.githubusercontent.com/113086103/218077638-f030d168-f235-41dc-ad89-cdb59796f8d1.png)
