### PR TITLE
feat(User) : 이메일을 이용한 회원 가입 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,14 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/com/zerobase/wishmarket/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/wishmarket/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.zerobase.wishmarket.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Slf4j
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    // 인증되지 않은 사용자 접근에 대한 handler
+//    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+//        https://myeongdev.tistory.com/m/29
+        http
+            .httpBasic().disable()
+            .csrf().disable() // csrf 방지
+            .cors().disable() // cors 방지
+            .formLogin().disable(); // 기본 로그인 페이지 없애기
+
+        // Spring Security에서 session을 생성하거나 사용하지 않도록 설정
+//            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        http
+            .authorizeRequests()
+            .antMatchers("/h2-console/**").permitAll() // 추가
+            .antMatchers("/**/**/sign-up", "/**/**/sign-in").permitAll();
+
+        // JWT filter 적용
+//        http
+//            .addFilterBefore(this.jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/h2-console/**");
+    }
+
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.zerobase.wishmarket.domain.user.controller;
 
 import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
-import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.dto.SignUpEmailDto;
 import com.zerobase.wishmarket.domain.user.service.UserSignUpService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class UserController {
     private final UserSignUpService userSignUpService;
 
     @PostMapping("/sign-up")
-    public ResponseEntity<UserDto> signUpEmail(@RequestBody @Valid SignUpForm form) {
+    public ResponseEntity<SignUpEmailDto> signUpEmail(@RequestBody @Valid SignUpForm form) {
         return ResponseEntity.ok(userSignUpService.signUp(form));
     }
 

--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.zerobase.wishmarket.domain.user.controller;
+
+import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.service.UserSignUpService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserSignUpService userSignUpService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<UserDto> signUpEmail(@RequestBody @Valid SignUpForm form) {
+        return ResponseEntity.ok(userSignUpService.signUp(form));
+    }
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,20 @@
+package com.zerobase.wishmarket.domain.user.exception;
+
+import com.zerobase.wishmarket.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 이메일 형식입니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 비밀번호 형식입니다."),
+    ALREADY_REGISTER_USER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
+
+        ;
+
+    private final HttpStatus errorCode;
+    private final String message;
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/exception/UserException.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/exception/UserException.java
@@ -1,0 +1,15 @@
+package com.zerobase.wishmarket.domain.user.exception;
+
+import com.zerobase.wishmarket.exception.GlobalException;
+import lombok.Getter;
+
+@Getter
+public class UserException extends GlobalException {
+
+    private final UserErrorCode userErrorCode;
+
+    public UserException(UserErrorCode userErrorCode) {
+        super(userErrorCode);
+        this.userErrorCode = userErrorCode;
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/SignUpEmailDto.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/SignUpEmailDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.wishmarket.domain.user.model.dto;
 
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import java.time.LocalDateTime;
@@ -14,16 +15,25 @@ import lombok.ToString;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserDto {
+public class SignUpEmailDto {
 
     private Long id;
     private String name;
     private String email;
     private String nickName;
-    private String phone;
-    private String profileImage;
     private UserRegistrationType userRegistrationType;
-    private UserStatusType userStatusType;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
+    public static SignUpEmailDto from(UserEntity userEntity){
+        return SignUpEmailDto.builder()
+            .id(userEntity.getUserId())
+            .name(userEntity.getName())
+            .email(userEntity.getEmail())
+            .nickName(userEntity.getNickName())
+            .userRegistrationType(userEntity.getUserRegistrationType())
+            .createdAt(userEntity.getCreatedAt())
+            .modifiedAt(userEntity.getModifiedAt())
+            .build();
+    }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/SignUpForm.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/SignUpForm.java
@@ -1,0 +1,29 @@
+package com.zerobase.wishmarket.domain.user.model.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpForm {
+    @NotNull
+    @Email(message = "옳바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String nickName;
+
+    @NotNull
+    private String password;
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/SignUpForm.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/SignUpForm.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class SignUpForm {
     @NotNull
-    @Email(message = "옳바른 이메일 형식이 아닙니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
     @NotNull

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/UserDto.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/UserDto.java
@@ -1,0 +1,29 @@
+package com.zerobase.wishmarket.domain.user.model.dto;
+
+import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDto {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String nickName;
+    private String phone;
+    private String profileImage;
+    private UserRegistrationType userRegistrationType;
+    private UserStatusType userStatusType;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
@@ -1,7 +1,7 @@
 package com.zerobase.wishmarket.domain.user.model.entity;
 
 import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
-import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.dto.SignUpEmailDto;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.model.type.UserRolesType;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
@@ -71,21 +71,6 @@ public class UserEntity extends BaseEntity {
             .nickName(form.getNickName())
             .password(form.getPassword())
             .userRegistrationType(userRegistrationType)
-            .build();
-    }
-
-    public UserDto toUserDto(){
-        return UserDto.builder()
-            .id(this.userId)
-            .name(this.name)
-            .email(this.email)
-            .nickName(this.nickName)
-            .phone(this.phone)
-            .profileImage(this.profileImage)
-            .userRegistrationType(this.userRegistrationType)
-            .userStatusType(this.userStatusType)
-            .createdAt(this.getCreatedAt())
-            .modifiedAt(this.getModifiedAt())
             .build();
     }
 

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
@@ -1,8 +1,10 @@
 package com.zerobase.wishmarket.domain.user.model.entity;
 
-import com.zerobase.wishmarket.domain.user.model.type.UserRegistration;
-import com.zerobase.wishmarket.domain.user.model.type.UserRoles;
-import com.zerobase.wishmarket.domain.user.model.type.UserStatus;
+import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.model.type.UserRolesType;
+import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import com.zerobase.wishmarket.entity.BaseEntity;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -48,17 +50,46 @@ public class UserEntity extends BaseEntity {
     private String profileImage; // 프로필 이미지 경로
 
     @Enumerated(EnumType.STRING)
-    private UserRegistration userRegistration;
+    private UserRegistrationType userRegistrationType;
 
     @Enumerated(EnumType.STRING)
-    private UserRoles userRole;
+    private UserRolesType userRoleType;
 
     @Enumerated(EnumType.STRING)
-    private UserStatus userStatus;
+    private UserStatusType userStatusType;
 
     // 1 : 1 Mapping
 
     // 주소
     @OneToOne(mappedBy = "userEntity", fetch = FetchType.LAZY)
     private DeliveryAddress deliveryAddress;
+
+    public static UserEntity of(SignUpForm form, UserRegistrationType userRegistrationType){
+        return UserEntity.builder()
+            .name(form.getName())
+            .email(form.getEmail())
+            .nickName(form.getNickName())
+            .password(form.getPassword())
+            .userRegistrationType(userRegistrationType)
+            .build();
+    }
+
+    public UserDto toUserDto(){
+        return UserDto.builder()
+            .id(this.userId)
+            .name(this.name)
+            .email(this.email)
+            .nickName(this.nickName)
+            .phone(this.phone)
+            .profileImage(this.profileImage)
+            .userRegistrationType(this.userRegistrationType)
+            .userStatusType(this.userStatusType)
+            .createdAt(this.getCreatedAt())
+            .modifiedAt(this.getModifiedAt())
+            .build();
+    }
+
+    public void setUserStatusType(UserStatusType userStatusType){
+        this.userStatusType = userStatusType;
+    }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/type/UserRegistrationType.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/type/UserRegistrationType.java
@@ -1,5 +1,5 @@
 package com.zerobase.wishmarket.domain.user.model.type;
 
-public enum UserRegistration {
+public enum UserRegistrationType {
     EMAIL, NAVER, GOOGLE
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/type/UserRolesType.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/type/UserRolesType.java
@@ -1,5 +1,5 @@
 package com.zerobase.wishmarket.domain.user.model.type;
 
-public enum UserStatus {
-    ACTIVE, INACTIVE, WITHDRAWAL
+public enum UserRolesType {
+    USER, ADMIN
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/type/UserStatusType.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/type/UserStatusType.java
@@ -1,5 +1,5 @@
 package com.zerobase.wishmarket.domain.user.model.type;
 
-public enum UserRoles {
-    USER, ADMIN
+public enum UserStatusType {
+    ACTIVE, WITHDRAWAL
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
@@ -1,8 +1,14 @@
 package com.zerobase.wishmarket.domain.user.repository;
 
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
+    Optional<UserEntity> findByEmailAndUserRegistrationType(String email, UserRegistrationType userRegistration);
+
+    boolean existsByEmailAndUserRegistrationType(String email, UserRegistrationType userRegistration);
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserSignUpService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserSignUpService.java
@@ -6,7 +6,7 @@ import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.INVALI
 
 import com.zerobase.wishmarket.domain.user.exception.UserException;
 import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
-import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.dto.SignUpEmailDto;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
@@ -28,7 +28,7 @@ public class UserSignUpService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public UserDto signUp(SignUpForm form) {
+    public SignUpEmailDto signUp(SignUpForm form) {
         if (checkInvalidEmail(form.getEmail())) {
             throw new UserException(INVALID_EMAIL_FORMAT);
         }
@@ -49,7 +49,7 @@ public class UserSignUpService {
             if (userEntity.getUserStatusType() == UserStatusType.WITHDRAWAL) {
                 userEntity.setUserStatusType(UserStatusType.ACTIVE);
 
-                return userRepository.save(userEntity).toUserDto();
+                return SignUpEmailDto.from(userRepository.save(userEntity));
             }
 
         }
@@ -60,8 +60,10 @@ public class UserSignUpService {
 
         form.setPassword(this.passwordEncoder.encode(form.getPassword()));
 
-        return userRepository.save(UserEntity.of(form, UserRegistrationType.EMAIL))
-            .toUserDto();
+        return SignUpEmailDto.from(
+            userRepository.save(UserEntity.of(form, UserRegistrationType.EMAIL))
+        );
+
     }
 
 
@@ -77,7 +79,7 @@ public class UserSignUpService {
     }
 
     private boolean checkInvalidPassword(String password) {
-        return !Pattern.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$",password);
+        return !Pattern.matches("^.{8,}$", password);
     }
 
 

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserSignUpService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserSignUpService.java
@@ -1,0 +1,84 @@
+package com.zerobase.wishmarket.domain.user.service;
+
+import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.ALREADY_REGISTER_USER;
+import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.INVALID_EMAIL_FORMAT;
+import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.INVALID_PASSWORD_FORMAT;
+
+import com.zerobase.wishmarket.domain.user.exception.UserException;
+import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
+import com.zerobase.wishmarket.domain.user.repository.UserRepository;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UserSignUpService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public UserDto signUp(SignUpForm form) {
+        if (checkInvalidEmail(form.getEmail())) {
+            throw new UserException(INVALID_EMAIL_FORMAT);
+        }
+
+        if (checkInvalidPassword(form.getPassword())) {
+            throw new UserException(INVALID_PASSWORD_FORMAT);
+        }
+
+        // 한번 탈퇴했던 회원이라면
+        // UserStatus : withdrawal -> active
+        Optional<UserEntity> optionalUser = userRepository.findByEmailAndUserRegistrationType(form.getEmail(),
+            UserRegistrationType.EMAIL);
+
+        if (optionalUser.isPresent()) {
+
+            UserEntity userEntity = optionalUser.get();
+
+            if (userEntity.getUserStatusType() == UserStatusType.WITHDRAWAL) {
+                userEntity.setUserStatusType(UserStatusType.ACTIVE);
+
+                return userRepository.save(userEntity).toUserDto();
+            }
+
+        }
+
+        if (isEmailExist(form.getEmail())) {
+            throw new UserException(ALREADY_REGISTER_USER);
+        }
+
+        form.setPassword(this.passwordEncoder.encode(form.getPassword()));
+
+        return userRepository.save(UserEntity.of(form, UserRegistrationType.EMAIL))
+            .toUserDto();
+    }
+
+
+    // 유저 Email + 가입 방식을 기반으로 중복 확인
+    private boolean isEmailExist(String email) {
+        return userRepository.existsByEmailAndUserRegistrationType(
+            email,
+            UserRegistrationType.EMAIL);
+    }
+
+    private boolean checkInvalidEmail(String email) {
+        return !Pattern.matches("^[a-zA-Z.].+[@][a-zA-Z].+[.][a-zA-Z]{2,4}$", email);
+    }
+
+    private boolean checkInvalidPassword(String password) {
+        return !Pattern.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$",password);
+    }
+
+
+}

--- a/src/test/java/com/zerobase/wishmarket/domain/user/service/UserSignUpServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/user/service/UserSignUpServiceTest.java
@@ -1,0 +1,112 @@
+package com.zerobase.wishmarket.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.zerobase.wishmarket.domain.user.exception.UserErrorCode;
+import com.zerobase.wishmarket.domain.user.exception.UserException;
+import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
+import com.zerobase.wishmarket.domain.user.repository.UserRepository;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserSignUpServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Spy
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserSignUpService userSignUpService;
+
+
+    @Test
+    void SignUp_Success() {
+        //given
+        SignUpForm form = SignUpForm.builder()
+            .email("test@naver.com")
+            .name("test")
+            .nickName("근것")
+            .password("won9975744!")
+            .build();
+
+        String encryptedPw = this.passwordEncoder.encode(form.getPassword());
+
+        given(userRepository.findByEmailAndUserRegistrationType(anyString(), any()))
+            .willReturn(Optional.empty());
+
+        given(userRepository.existsByEmailAndUserRegistrationType(anyString(), any()))
+            .willReturn(false);
+
+        given(userRepository.save(any()))
+            .willReturn(UserEntity.builder()
+                .userId(1L)
+                .email("test@naver.com")
+                .name("test")
+                .password(encryptedPw)
+                .build());
+
+        // save에서 저장되는 실제 계좌는 captor 안으로 들어감.
+
+        //when
+        UserDto userDto = userSignUpService.signUp(form);
+
+
+        //then
+        assertEquals(1L, userDto.getId());
+        assertEquals("test@naver.com", userDto.getEmail());
+        assertEquals("test", userDto.getName());
+    }
+
+    @Test
+    void EmailExist_Fail() {
+        // given
+        SignUpForm form = SignUpForm.builder()
+            .email("test@naver.com")
+            .name("test")
+            .password("won9975744!")
+            .build();
+
+        given(userRepository.existsByEmailAndUserRegistrationType(anyString(), any()))
+            .willReturn(true);
+
+        //when
+        UserException userException = assertThrows(UserException.class,
+            () -> userSignUpService.signUp(form));
+
+        //then
+        assertEquals(UserErrorCode.ALREADY_REGISTER_USER, userException.getUserErrorCode());
+    }
+
+    public UserEntity createWithdrawalUserEntity(String encryptedPw) {
+        return UserEntity.builder()
+            .userId(10L)
+            .name("test")
+            .email("test@naver.com")
+            .nickName("근것")
+            .password(encryptedPw)
+            .userStatusType(UserStatusType.WITHDRAWAL)
+            .build();
+    }
+
+
+}

--- a/src/test/java/com/zerobase/wishmarket/domain/user/service/UserSignUpServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/user/service/UserSignUpServiceTest.java
@@ -5,21 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.zerobase.wishmarket.domain.user.exception.UserErrorCode;
 import com.zerobase.wishmarket.domain.user.exception.UserException;
 import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
-import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.dto.SignUpEmailDto;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import com.zerobase.wishmarket.domain.user.repository.UserRepository;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -68,7 +65,7 @@ class UserSignUpServiceTest {
         // save에서 저장되는 실제 계좌는 captor 안으로 들어감.
 
         //when
-        UserDto userDto = userSignUpService.signUp(form);
+        SignUpEmailDto userDto = userSignUpService.signUp(form);
 
 
         //then


### PR DESCRIPTION
## 관련 이슈
- #14 

<br>

## 변경사항

- 이메일, 비밀번호 정규식을 검사합니다.
- 이미 가입된 유저일 경우 "이미 가입된 회원입니다." 라는 에러를 반환합니다.
- 회원의 status가 "탈퇴" 일 경우 회원가입 시 status만 active로 변경하여 재 가입합니다.
- 비밀 번호의 경우 암호화를 하여 DB에 저장합니다.

<br>


## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?
