### PR TITLE
feat(Product) : 카테고리별 상품 리스트 조회 및 베스트 상품 리스트 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ dependencies {
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2'
@@ -33,6 +38,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.batch:spring-batch-test'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/src/main/java/com/zerobase/wishmarket/WishMarketApplication.java
+++ b/src/main/java/com/zerobase/wishmarket/WishMarketApplication.java
@@ -1,9 +1,14 @@
 package com.zerobase.wishmarket;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
 @EnableJpaAuditing
+@EnableBatchProcessing
+@EnableScheduling
 @SpringBootApplication
 public class WishMarketApplication {
 

--- a/src/main/java/com/zerobase/wishmarket/config/BatchJob.java
+++ b/src/main/java/com/zerobase/wishmarket/config/BatchJob.java
@@ -1,0 +1,86 @@
+package com.zerobase.wishmarket.config;
+
+import com.zerobase.wishmarket.domain.product.model.entity.Product;
+import com.zerobase.wishmarket.domain.product.repository.ProductRepository;
+import com.zerobase.wishmarket.domain.product.service.ProductService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class BatchJob {
+
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final ProductService productService;
+    private final ProductRepository productRepository;
+
+    //서버 처음 구동시, 상품 데이터 넣기
+    @Bean
+    public Job JobToInputProduct() {
+        return jobBuilderFactory.get("JobToInputProduct")
+            .start(InputProductStep())
+            .on("FAILED")
+            .end()
+            .from(InputProductStep())
+            .on("*")
+            .end()
+            .end()
+            .build();
+    }
+
+    @Bean
+    public Step InputProductStep() {
+        return stepBuilderFactory.get("InputProductStep")
+            .tasklet((contribution, chunkContext) -> {
+                log.debug("===== 상품 데이터 저장 ====");
+                Optional<Product> product = productRepository.findById(1L);
+                if (product.isPresent()) {  //상품 데이터가 이미 존재한다면 실패
+                    contribution.setExitStatus(ExitStatus.FAILED);
+                }
+
+                productService.addProduct();
+                return RepeatStatus.FINISHED;
+            })
+            .build();
+    }
+
+
+    //Best 상품 초기화
+    @Bean
+    public Job JobToUpdateBestProduct() {
+        return jobBuilderFactory.get("JobToUpdateBestProduct")
+            .start(UpdateBestProductStep())
+            .on("FAILED")
+            .end()
+            .from(UpdateBestProductStep())
+            .on("*")
+            .end()
+            .end()
+            .build();
+    }
+
+    @Bean
+    public Step UpdateBestProductStep() {
+        return stepBuilderFactory.get("UpdateBestProductStep")
+            .tasklet((contribution, chunkContext) -> {
+                log.debug("===== 베스트 상품 업데이트 ====");
+                productService.updateBestProducts();
+                return RepeatStatus.FINISHED;
+            })
+            .build();
+    }
+
+
+
+}

--- a/src/main/java/com/zerobase/wishmarket/config/BatchScheduler.java
+++ b/src/main/java/com/zerobase/wishmarket/config/BatchScheduler.java
@@ -1,0 +1,45 @@
+package com.zerobase.wishmarket.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BatchScheduler {
+
+    private final JobLauncher jobLauncher;
+
+    private final BatchJob batchJob;
+
+    //베스트 상품, 매일 자정 2시 업데이트
+    @Scheduled(cron = "* 0 2 * * *")
+    public void runJob() {
+        Map<String, JobParameter> confMap = new HashMap<>();
+        confMap.put("time", new JobParameter(System.currentTimeMillis()));
+        JobParameters jobParameters = new JobParameters(confMap);
+
+        try {
+            log.debug("===== 베스트 상품 업데이트 ====");
+            jobLauncher.run(batchJob.JobToUpdateBestProduct(), jobParameters);
+        } catch (JobExecutionAlreadyRunningException | JobInstanceAlreadyCompleteException
+                 | JobParametersInvalidException |
+                 org.springframework.batch.core.repository.JobRestartException e) {
+            log.error(e.getMessage());
+        }
+
+
+    }
+
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/controller/ProductController.java
@@ -40,5 +40,4 @@ public class ProductController {
         return ResponseEntity.ok().body(productService.getBestProducts());
     }
 
-
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.zerobase.wishmarket.domain.product.controller;
 
+import com.zerobase.wishmarket.domain.product.model.ProductInputForm;
 import com.zerobase.wishmarket.domain.product.model.entity.Product;
 import com.zerobase.wishmarket.domain.product.model.type.ProductCategory;
 import com.zerobase.wishmarket.domain.product.service.ProductService;
@@ -9,6 +10,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,5 +42,15 @@ public class ProductController {
     public ResponseEntity<List<Product>> getBestProductList() {
         return ResponseEntity.ok().body(productService.getBestProducts());
     }
+
+    //상품 데이터 넣기
+    @PostMapping("/api/product/add")
+    public ResponseEntity addProduct(@ModelAttribute ProductInputForm productInputForm) {
+        productService.addProductData(productInputForm);
+        return ResponseEntity.ok().body("상품 정보가 정상적으로 업로드 되었습니다.");
+    }
+
+
+
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/controller/ProductController.java
@@ -1,13 +1,44 @@
 package com.zerobase.wishmarket.domain.product.controller;
 
+import com.zerobase.wishmarket.domain.product.model.entity.Product;
+import com.zerobase.wishmarket.domain.product.model.type.ProductCategory;
+import com.zerobase.wishmarket.domain.product.service.ProductService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/product")
 @RequiredArgsConstructor
 public class ProductController {
+
+    private final ProductService productService;
+
+
+    //카테고리별 상품 조회
+    @GetMapping("/category")
+    public Page<List<Product>> getProductListByCategory(
+        @RequestParam ProductCategory categories,
+        @RequestParam("page") Integer page, @RequestParam("size") Integer size) {
+
+        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        return ResponseEntity.ok()
+            .body(productService.getProductByCategory(categories, pageRequest))
+            .getBody();
+    }
+
+
+    //베스트 상품 조회
+    @GetMapping("/best")
+    public ResponseEntity<List<Product>> getBestProductList() {
+        return ResponseEntity.ok().body(productService.getBestProducts());
+    }
 
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/controller/ProductController.java
@@ -23,14 +23,14 @@ public class ProductController {
 
     //카테고리별 상품 조회
     @GetMapping("/category")
-    public Page<List<Product>> getProductListByCategory(
+    public Page<Product> getProductListByCategory(
         @RequestParam ProductCategory categories,
         @RequestParam("page") Integer page, @RequestParam("size") Integer size) {
 
         PageRequest pageRequest = PageRequest.of(page - 1, size);
         return ResponseEntity.ok()
-            .body(productService.getProductByCategory(categories, pageRequest))
-            .getBody();
+            .body(productService.getProductByCategory(categories, pageRequest)).getBody();
+
     }
 
 

--- a/src/main/java/com/zerobase/wishmarket/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/exception/ProductErrorCode.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ProductErrorCode implements ErrorCode {
     PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당하는 상품이 존재하지 않습니다."),
+    BEST_PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "배스트 상품을 불러오는데 실패하였습니다."),
+
 
     ;
 

--- a/src/main/java/com/zerobase/wishmarket/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/exception/ProductErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ProductErrorCode implements ErrorCode {
     PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당하는 상품이 존재하지 않습니다."),
-    BEST_PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "배스트 상품을 불러오는데 실패하였습니다."),
+    BEST_PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "베스트 상품을 불러오는데 실패하였습니다."),
 
 
     ;

--- a/src/main/java/com/zerobase/wishmarket/domain/product/model/ProductInputForm.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/model/ProductInputForm.java
@@ -1,0 +1,28 @@
+package com.zerobase.wishmarket.domain.product.model;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductInputForm {
+
+    @NotBlank
+    private String name;
+
+    private MultipartFile image;
+
+    private int categoryCode;
+
+    private int price;
+
+    private String description;
+
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/Best.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/Best.java
@@ -6,11 +6,13 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 @Entity
 public class Best {
 

--- a/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/Product.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/Product.java
@@ -24,7 +24,7 @@ import org.hibernate.envers.AuditOverride;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AuditOverride(forClass = BaseEntity.class)
 @Entity
-public class Product extends BaseEntity  {
+public class Product extends BaseEntity {
 
     @Id
     @Column(name = "product_id")
@@ -42,6 +42,8 @@ public class Product extends BaseEntity  {
 
     private String description;
 
+    private boolean isBest;
+
 
     @OneToOne
     @JoinColumn(name = "product_id")
@@ -50,5 +52,14 @@ public class Product extends BaseEntity  {
     public int getLikes() {
         return productLikes.getLikes();
     }
+
+    public void setIsBestFalse() {
+        this.isBest = false;
+    }
+
+    public void setIsBestTrue() {
+        this.isBest = true;
+    }
+
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/ProductLikes.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/ProductLikes.java
@@ -3,6 +3,7 @@ package com.zerobase.wishmarket.domain.product.model.entity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import lombok.Setter;
 @Setter
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductLikes {
 
     @Id

--- a/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/RedisBestProducts.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/RedisBestProducts.java
@@ -1,0 +1,21 @@
+package com.zerobase.wishmarket.domain.product.model.entity;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@ToString
+@RedisHash("BEST_PRODUCTS")
+@Builder
+public class RedisBestProducts {
+
+    @Id
+    private Long id;
+
+    private List<Product> products;
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/Review.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/model/entity/Review.java
@@ -1,5 +1,6 @@
 package com.zerobase.wishmarket.domain.product.model.entity;
 
+import com.zerobase.wishmarket.entity.BaseEntity;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -8,15 +9,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.hibernate.envers.AuditOverride;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@AuditOverride(forClass = BaseEntity.class)
 @Entity
-public class Review {
+public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,6 +29,6 @@ public class Review {
 
     private boolean isRecommend;
 
-    private Long ProductId;
+    private Long productId;
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/product/repository/BestRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/repository/BestRepository.java
@@ -1,10 +1,14 @@
 package com.zerobase.wishmarket.domain.product.repository;
 
 import com.zerobase.wishmarket.domain.product.model.entity.Best;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BestRepository extends JpaRepository<Best,Long> {
+    @Query("select b.productId from Best b")
+    List<Long> findBestList();
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/repository/ProductRepository.java
@@ -1,10 +1,21 @@
 package com.zerobase.wishmarket.domain.product.repository;
 
 import com.zerobase.wishmarket.domain.product.model.entity.Product;
+import com.zerobase.wishmarket.domain.product.model.type.ProductCategory;
+import java.util.List;
+import java.util.Set;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+    Page<List<Product>> findAllByCategory(ProductCategory category, Pageable pageable);
+
+
+    List<Product> findAllByProductIdIn(Set<Long> ids);
 }
+
+

--- a/src/main/java/com/zerobase/wishmarket/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/repository/ProductRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    Page<List<Product>> findAllByCategory(ProductCategory category, Pageable pageable);
+    Page<Product> findAllByCategory(ProductCategory category, Pageable pageable);
 
 
     List<Product> findAllByProductIdIn(Set<Long> ids);

--- a/src/main/java/com/zerobase/wishmarket/domain/product/repository/RedisBestRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/repository/RedisBestRepository.java
@@ -1,0 +1,7 @@
+package com.zerobase.wishmarket.domain.product.repository;
+
+import com.zerobase.wishmarket.domain.product.model.entity.RedisBestProducts;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RedisBestRepository extends CrudRepository<RedisBestProducts, Long> {
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/service/ProductService.java
@@ -106,9 +106,9 @@ public class ProductService {
     }
 
     //카테고리별 상품 조회
-    public Page<List<Product>> getProductByCategory(ProductCategory category,
+    public Page<Product> getProductByCategory(ProductCategory category,
         PageRequest pageRequest) {
-        Page<List<Product>> productList = productRepository.findAllByCategory(category,
+        Page<Product> productList = productRepository.findAllByCategory(category,
             pageRequest);
         return productList;
     }

--- a/src/main/java/com/zerobase/wishmarket/domain/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/service/ProductService.java
@@ -104,6 +104,4 @@ public class ProductService {
         return productList;
     }
 
-
-
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/service/ProductService.java
@@ -1,13 +1,108 @@
 package com.zerobase.wishmarket.domain.product.service;
 
+import com.zerobase.wishmarket.domain.product.exception.ProductErrorCode;
+import com.zerobase.wishmarket.domain.product.exception.ProductException;
+import com.zerobase.wishmarket.domain.product.model.entity.Product;
+import com.zerobase.wishmarket.domain.product.model.entity.ProductLikes;
+import com.zerobase.wishmarket.domain.product.model.type.ProductCategory;
+import com.zerobase.wishmarket.domain.product.repository.ProductLikesRepository;
+import com.zerobase.wishmarket.domain.product.repository.ProductRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 
 @Service
+@Configuration
+@Slf4j
 @RequiredArgsConstructor
 public class ProductService {
 
+    private final ProductRepository productRepository;
+    private final ProductLikesRepository productLikesRepository;
 
+    private final RedisTemplate<String, String> redisTemplate;
+    private static SetOperations<String, String> setOperations;
+
+    private static final String KEY_BEST_PRODUCTS = "BEST_PRODUCTS";
+
+
+    //임시로 제품 정보 넣기, Batch로 서버 시작시 데이터 저장, 추후 변경
+    public void addProduct() {
+        for (ProductCategory category : ProductCategory.values()) {
+            for (int i = 0; i < 20; i++) {
+                Product product = Product.builder()
+                    .name("제품" + i)
+                    .productImage("제품" + i + "파일 경로")
+                    .category(category)
+                    .price(1000)
+                    .description("제품설명" + i)
+                    .build();
+                productRepository.save(product);
+
+                ProductLikes productLikes = ProductLikes.builder()
+                    .productId(product.getProductId())
+                    .likes(0)
+                    .build();
+                productLikesRepository.save(productLikes);
+            }
+        }
+    }
+
+    //베스트 상품 12개 업데이트
+    public boolean updateBestProducts() {
+
+        //남아있던 정보 삭제
+        redisTemplate.delete(KEY_BEST_PRODUCTS);
+        List<ProductLikes> bestProductLikes = productLikesRepository.findTop12ByOrderByLikesDesc();
+
+        setOperations = redisTemplate.opsForSet();
+
+        for (int i = 0; i < bestProductLikes.size(); i++) {
+            setOperations.add(KEY_BEST_PRODUCTS,
+                Long.toString(bestProductLikes.get(i).getProductId()));
+        }
+        return true;
+    }
+
+    //카테고리별 상품 조회
+    public Page<List<Product>> getProductByCategory(ProductCategory category,
+        PageRequest pageRequest) {
+        Page<List<Product>> productList = productRepository.findAllByCategory(category,
+            pageRequest);
+        return productList;
+    }
+
+
+    //베스트 상품 조회
+    public List<Product> getBestProducts() {
+
+        //Redis에 저장되어있는 Best 상품에 대한 ID들을 가져옴
+        Set<String> bestSets= setOperations.members(KEY_BEST_PRODUCTS);
+        if(bestSets.isEmpty()){
+            throw new ProductException(ProductErrorCode.BEST_PRODUCT_NOT_FOUND);
+        }
+
+        //Long 타입으로 전환 (redis가 Long타입으로 저장이 안되는데 아시는분은 말씀해주세요!,,)
+        Set<Long> bestListToLong = new HashSet<>();
+        for (String s : bestSets) {
+            bestListToLong.add(Long.valueOf(s));
+        }
+
+        List<Product> productList = productRepository.findAllByProductIdIn(bestListToLong);
+        if (productList.isEmpty()) {
+            throw new ProductException(ProductErrorCode.BEST_PRODUCT_NOT_FOUND);
+        }
+
+        return productList;
+    }
 
 
 

--- a/src/main/java/com/zerobase/wishmarket/domain/product/service/ProductService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/product/service/ProductService.java
@@ -4,19 +4,18 @@ import com.zerobase.wishmarket.domain.product.exception.ProductErrorCode;
 import com.zerobase.wishmarket.domain.product.exception.ProductException;
 import com.zerobase.wishmarket.domain.product.model.entity.Product;
 import com.zerobase.wishmarket.domain.product.model.entity.ProductLikes;
+import com.zerobase.wishmarket.domain.product.model.entity.RedisBestProducts;
 import com.zerobase.wishmarket.domain.product.model.type.ProductCategory;
 import com.zerobase.wishmarket.domain.product.repository.ProductLikesRepository;
 import com.zerobase.wishmarket.domain.product.repository.ProductRepository;
-import java.util.HashSet;
+import com.zerobase.wishmarket.domain.product.repository.RedisBestRepository;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,10 +27,9 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final ProductLikesRepository productLikesRepository;
 
-    private final RedisTemplate<String, String> redisTemplate;
-    private static SetOperations<String, String> setOperations;
+    private final RedisBestRepository redisBestRepository;
 
-    private static final String KEY_BEST_PRODUCTS = "BEST_PRODUCTS";
+    private static final Long KEY_BEST_PRODUCTS = 1L;
 
 
     //임시로 제품 정보 넣기, Batch로 서버 시작시 데이터 저장, 추후 변경
@@ -39,7 +37,7 @@ public class ProductService {
         for (ProductCategory category : ProductCategory.values()) {
             for (int i = 1; i < 21; i++) {
                 Product product = Product.builder()
-                    .name("제품" + i)
+                    .name("product" + i)
                     .productImage("제품" + i + "파일 경로")
                     .category(category)
                     .price(1000)
@@ -57,50 +55,33 @@ public class ProductService {
 
         //베스트 상품 등록을 위해 likes 수 몇개만 변경
         for (Long i = 1L; i < 13L; i++) {
-            ProductLikes productLikes = productLikesRepository.findById(i).orElseThrow(()->new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+            ProductLikes productLikes = productLikesRepository.findById(i)
+                .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
             productLikes.setLikes(10);
         }
     }
 
-    //베스트 상품 12개 업데이트
+
+    //베스트 상품 N개 업데이트
     public boolean updateBestProducts() {
 
-        setOperations = redisTemplate.opsForSet();
+        //베스트 상품
+        redisBestRepository.deleteAll();
 
-        //베스트 상품을 삭제하기 전에, 상품 데이터에 isBest가 true인 데이터들을 false로 초기화
-        List<Product> products = productRepository.findAll();
-        for(Product product : products){
-            if(product.isBest() == true ){
-                product.setIsBestFalse();
-            }
-        }
+        //문제의 정렬 부분
+        List<ProductLikes> bestProductLikes = productLikesRepository.findTop50ByOrderByLikesDesc();
 
-        //redis에 남아있던 베스트 상품 정보 삭제
-        redisTemplate.delete(KEY_BEST_PRODUCTS);
-
-
-        //Redis에 새로 저장할 베스트 상품 id 목록 업데이트
-        List<ProductLikes> bestProductLikes = productLikesRepository.findTop12ByOrderByLikesDesc();
-
+        List<Long> ids = new ArrayList<>();
         for (int i = 0; i < bestProductLikes.size(); i++) {
-            setOperations.add(KEY_BEST_PRODUCTS,
-                Long.toString(bestProductLikes.get(i).getProductId()));
+            ids.add(bestProductLikes.get(i).getProductId());
         }
 
-        Set<String> bestSets = setOperations.members(KEY_BEST_PRODUCTS);
-        Set<Long> bestListToLong = new HashSet<>();
-
-        //Long 타입으로 전환
-        for (String s : bestSets) {
-            bestListToLong.add(Long.valueOf(s));
-        }
-
-        //Redis에 저장된 베스트 상품id에 따라, 상품 데이터의 isBest = true로 변경
-        for (Long productId : bestListToLong) {
-            Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
-            product.setIsBestTrue();
-        }
+        //redis repository에 넣기
+        List<Product> productList = productRepository.findAllByProductIdIn(ids);
+        redisBestRepository.save(RedisBestProducts.builder()
+            .id(KEY_BEST_PRODUCTS)
+            .products(productList)
+            .build());
 
         return true;
     }
@@ -116,25 +97,10 @@ public class ProductService {
 
     //베스트 상품 조회
     public List<Product> getBestProducts() {
-
-        //Redis에 저장되어있는 Best 상품에 대한 ID들을 가져옴
-        Set<String> bestSets = setOperations.members(KEY_BEST_PRODUCTS);
-        if (bestSets.isEmpty()) {
-            throw new ProductException(ProductErrorCode.BEST_PRODUCT_NOT_FOUND);
-        }
-
-        //Long 타입으로 전환 (redis가 Long타입으로 저장이 안되는데 아시는분은 말씀해주세요!,,)
-        Set<Long> bestListToLong = new HashSet<>();
-        for (String s : bestSets) {
-            bestListToLong.add(Long.valueOf(s));
-        }
-
-        List<Product> productList = productRepository.findAllByProductIdIn(bestListToLong);
-        if (productList.isEmpty()) {
-            throw new ProductException(ProductErrorCode.BEST_PRODUCT_NOT_FOUND);
-        }
-
+        List<Product> productList = redisBestRepository.findById(KEY_BEST_PRODUCTS).get().getProducts();
         return productList;
     }
+
+
 
 }

--- a/src/test/java/com/zerobase/wishmarket/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/product/service/ProductServiceTest.java
@@ -39,7 +39,7 @@ class ProductServiceTest {
         PageRequest pageRequest = PageRequest.of(1, 12);
 
         for(ProductCategory category : ProductCategory.values()){
-            Page<List<Product>> productList = productRepository.findAllByCategory(category,
+            Page<Product> productList = productRepository.findAllByCategory(category,
                 pageRequest);
 
             if(productList.isEmpty()){

--- a/src/test/java/com/zerobase/wishmarket/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/product/service/ProductServiceTest.java
@@ -1,0 +1,64 @@
+package com.zerobase.wishmarket.domain.product.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.zerobase.wishmarket.domain.product.exception.ProductErrorCode;
+import com.zerobase.wishmarket.domain.product.exception.ProductException;
+import com.zerobase.wishmarket.domain.product.model.entity.Product;
+import com.zerobase.wishmarket.domain.product.model.type.ProductCategory;
+import com.zerobase.wishmarket.domain.product.repository.ProductRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource("classpath:application.properties")
+@SpringBootTest
+class ProductServiceTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductService productService;
+
+
+
+    //카테고리별 상품 조회
+    @Test
+    public void testSearchProductCategory() {
+        PageRequest pageRequest = PageRequest.of(1, 12);
+
+        for(ProductCategory category : ProductCategory.values()){
+            Page<List<Product>> productList = productRepository.findAllByCategory(category,
+                pageRequest);
+
+            if(productList.isEmpty()){
+                throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
+            }
+            //각 카테고리별로 제품을 성공적으로 가져오는지 확인
+            assertNotNull(productList);
+        }
+
+    }
+
+
+
+    //베스트 상품 조회
+    @Test
+    public void testBestProducts() {
+        List<Product> bestProducts = productService.getBestProducts();
+        if(bestProducts.isEmpty()){
+            throw new ProductException(ProductErrorCode.BEST_PRODUCT_NOT_FOUND);
+        }
+
+        assertNotNull(bestProducts);
+    }
+
+
+
+
+}

--- a/src/test/java/com/zerobase/wishmarket/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/product/service/ProductServiceTest.java
@@ -59,6 +59,4 @@ class ProductServiceTest {
     }
 
 
-
-
 }


### PR DESCRIPTION
## 변경사항

1. 서버 구동시 상품 데이터를 일괄처리 합니다.
2. 서버 구동시 베스트 상품Id 목록을 redis를 활용해 캐시화 하여 저장합니다.
3. 베스트 상품 업데이트는 매일 자정 2시에 이루어 집니다.


## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?

개발 과정에서 임시로 상품 데이터가 필요하여, 서버 구동시 상품데이터를 db에 넣습니다.
![image](https://user-images.githubusercontent.com/79897135/218314489-9e79fa66-486b-48fd-a5d3-083b42ade24e.png)

베스트 상품 목록을 매일 자정2시에 업데이트 합니다.
![image](https://user-images.githubusercontent.com/79897135/218314510-6bd68e72-6c31-4663-9cae-b04d7c3f2e87.png)

(Redis에 베스트 상품Id들이 저장되어있는 모습)
![image](https://user-images.githubusercontent.com/79897135/218313209-2c8c1e62-70ce-4479-9931-e70ea7242e20.png)


=================================================================================
카테고리별 제품 리스트 조회
(요청의 Page, Size 값에 맞게 결과값을 반환합니다)
![image](https://user-images.githubusercontent.com/79897135/218321959-40349b2f-71a5-4409-995f-cb66a76262e2.png)
![image](https://user-images.githubusercontent.com/79897135/218322024-a2c8b120-cb23-441f-b154-43b62821e183.png)


베스트 상품 리스트 조회
![image](https://user-images.githubusercontent.com/79897135/218322042-5939c21f-2396-4a9d-87c6-3580196c0681.png)
![image](https://user-images.githubusercontent.com/79897135/218322065-9275ee3e-935b-4973-b292-3a8d07d85298.png)

=================================================================================
상품 추가 api
![image](https://user-images.githubusercontent.com/79897135/218727380-29a18c93-da7f-4e8c-b8da-d497343a0b08.png)
(상품 카테고리는 저희가 정한 코드값으로 넣으면 됩니다.)
- 0 : 의류
- 1 : 가전
- 2 : 고가 레고 (완구)
- 3 : IT
- 4 : 귀금속
- 5 : 가구
- 6 : 기타
