### PR TITLE
fix(User) : OAuth2 로그인 유저 정보 활용 방법 수정 (Session->JWT)

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserAuthController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserAuthController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
 
 
 @RestController
@@ -23,27 +24,27 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserAuthController {
 
     private final UserAuthService userAuthService;
+    private final RedirectView redirectView;
 
     @PostMapping("/sign-up")
     public ResponseEntity<SignUpEmailResponse> signUpEmail(@RequestBody @Valid SignUpForm form) {
         return ResponseEntity.ok(userAuthService.signUp(form));
     }
 
-    @PostMapping("/sign-in")
+    @PostMapping("/sign-in/email")
     public ResponseEntity<?> signInEmail(@RequestBody @Valid SignInForm form) {
-        return ResponseEntity.ok(userAuthService.signIn(form));
+        return ResponseEntity.ok(userAuthService.signInEmail(form));
     }
 
-    // UserAuthContoller
-    @GetMapping("/social-sign-in")
-    // 기존 : httpSession.getAttribute 로 가져오던 세션 정보
-    // 수정 : 어느 컨트롤러에서든 @LoginUserInfo 를 사용하여 세션 정보 활용 가능
-    public String oauthLoginInfo(Model model, @LoginUserInfo OAuthUserInfo user) {
+    @PostMapping("/sign-in/google")
+    public ResponseEntity<?> signInGoogle(@LoginUserInfo OAuthUserInfo userInfo) {
+        redirectView.setUrl("/oauth2/authorization/google");
+        return ResponseEntity.ok(userAuthService.signInSocial(userInfo));
+    }
 
-        if (user != null) {
-            model.addAttribute("userName", user.getName());
-        }
-
-        return "oauthLoginInfo";
+    @PostMapping("/sign-in/naver")
+    public ResponseEntity<?> signInNaver(@LoginUserInfo OAuthUserInfo userInfo) {
+        redirectView.setUrl("/oauth2/authorization/naver");
+        return ResponseEntity.ok(userAuthService.signInSocial(userInfo));
     }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserAuthController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserAuthController.java
@@ -24,7 +24,7 @@ import org.springframework.web.servlet.view.RedirectView;
 public class UserAuthController {
 
     private final UserAuthService userAuthService;
-    private final RedirectView redirectView;
+//    private final RedirectView redirectView;
 
     @PostMapping("/sign-up")
     public ResponseEntity<SignUpEmailResponse> signUpEmail(@RequestBody @Valid SignUpForm form) {
@@ -38,13 +38,13 @@ public class UserAuthController {
 
     @PostMapping("/sign-in/google")
     public ResponseEntity<?> signInGoogle(@LoginUserInfo OAuthUserInfo userInfo) {
-        redirectView.setUrl("/oauth2/authorization/google");
+//        redirectView.setUrl("/oauth2/authorization/google");
         return ResponseEntity.ok(userAuthService.signInSocial(userInfo));
     }
 
     @PostMapping("/sign-in/naver")
     public ResponseEntity<?> signInNaver(@LoginUserInfo OAuthUserInfo userInfo) {
-        redirectView.setUrl("/oauth2/authorization/naver");
+//        redirectView.setUrl("/oauth2/authorization/naver");
         return ResponseEntity.ok(userAuthService.signInSocial(userInfo));
     }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/OAuthService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/OAuthService.java
@@ -1,8 +1,7 @@
 package com.zerobase.wishmarket.domain.user.service;
 
-import com.zerobase.wishmarket.domain.user.model.dto.OAuthUserInfo;
-import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.dto.OAuthAttributes;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.repository.UserAuthRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -14,14 +13,12 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpSession;
 import java.util.Collections;
 
 @RequiredArgsConstructor
 @Service
 public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     private final UserAuthRepository userAuthRepository;
-    private final HttpSession httpSession;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -38,8 +35,6 @@ public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
 
         UserEntity userEntity = saveOrUpdate(attributes);
-        // 세션에 사용자 정보를 저장하기 위한 Dto 클래스 : SessionUser
-        httpSession.setAttribute("user", new OAuthUserInfo(userEntity));
 
         return new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority("USER")),

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserAuthService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserAuthService.java
@@ -126,8 +126,6 @@ public class UserAuthService {
                 .name(user.getName())
                 .accessToken(TOKEN_PREFIX + tokenSetDto.getAccessToken())
                 .accessTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getAccessToken())))
-                .refreshToken(tokenSetDto.getRefreshToken())
-                .refreshTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getRefreshToken())))
                 .build();
     }
 

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserAuthService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserAuthService.java
@@ -2,11 +2,7 @@ package com.zerobase.wishmarket.domain.user.service;
 
 import static com.zerobase.wishmarket.common.jwt.model.constants.JwtConstants.REFRESH_TOKEN_PREFIX;
 import static com.zerobase.wishmarket.common.jwt.model.constants.JwtConstants.TOKEN_PREFIX;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.ALREADY_REGISTER_USER;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.EMAIL_NOT_FOUND;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.INVALID_EMAIL_FORMAT;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.INVALID_PASSWORD_FORMAT;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.PASSWORD_DO_NOT_MATCH;
+import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.*;
 
 import com.zerobase.wishmarket.common.jwt.JwtAuthenticationProvider;
 import com.zerobase.wishmarket.common.jwt.model.dto.TokenSetDto;
@@ -112,7 +108,7 @@ public class UserAuthService {
     public SignInResponse signInSocial(OAuthUserInfo userInfo) {
 
         UserEntity user = userAuthRepository.findByEmail(userInfo.getEmail())
-                .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
         TokenSetDto tokenSetDto = jwtProvider.generateTokenSet(userInfo.getUserId());
 
         // 작성된 날짜에서 현재 날짜를 빼고 밀리초로 나누면 지나간 시간(초)이 계산


### PR DESCRIPTION
## 관련이슈
- #36

## 변경사항
- 기존에는 OAuth2 인증 방식을 통해 로그인한 유저의 정보를 세션에 담아 사용하고 있었습니다.
- 이메일 로그인 유저와 유저 정보 활용 방식을 통일하기 위해 소셜 로그인 유저 또한 JWT를 생성하고 이를 활용하도록 변경했습니다.

## 기타 사항
- OAuth2 로그인 화면을 동작시키기 위해서 컨트롤러의 RedirectView 에 작성된 Url 로 이동하여야 로그인 화면을 확인할 수 있습니다.
- google과 naver의 요청화면이 다르기 때문에 컨트롤러에서는 분리했으나 내부에서 요청하는 Service의 로직은 동일합니다.
- 그리고 해당 View에서 로그인이 정상적으로 동작하면 OAuth2 서비스에 등록된 Redirect Url을 통해 원하는 페이지로 돌아오게 됩니다.
- 위와 같은 과정은 프론트 수강생들과 연동하는 과정에서 테스트가 이루어져야 할 것 같아 일단 코드로 남겨놓았습니다.

## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [X]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [ ]  모든 **테스트**가 성공했나요?