### PR TITLE
feat(WishList): 사용자의 찜목록 추가, 조회, 삭제 구현

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
@@ -1,0 +1,54 @@
+package com.zerobase.wishmarket.domain.wishList.controller;
+
+import com.zerobase.wishmarket.common.jwt.JwtAuthenticationProvider;
+import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
+import com.zerobase.wishmarket.domain.wishList.service.WishListService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/wishlist")
+@RequiredArgsConstructor
+public class WishListController {
+
+    private final WishListService wishListService;
+
+    private final JwtAuthenticationProvider provider;
+
+
+    //위시리스트 추가
+    @PostMapping("/add")
+    public ResponseEntity<WishList> add(@RequestHeader("Authorization") String token,
+        @RequestParam Long productId) {
+        String userId = provider.getUserId(token);
+        return ResponseEntity.ok()
+            .body(wishListService.addWishList(Long.valueOf(userId), productId));
+    }
+
+    //위시리스트 조회
+    @GetMapping
+    public ResponseEntity<List<WishList>> get(@RequestHeader("Authorization") String token) {
+        String userId = provider.getUserId(token);
+
+        return ResponseEntity.ok().body(wishListService.getWishList(Long.valueOf(userId)));
+    }
+
+
+    //위시리스트 삭제
+    @DeleteMapping
+    public ResponseEntity<Boolean> delete(@RequestHeader("Authorization") String token,
+        @RequestParam Long wishListId) {
+        return ResponseEntity.ok()
+            .body(wishListService.deleteWishList(wishListId));
+
+    }
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
@@ -35,6 +35,10 @@ public class WishListController {
                 .body(wishListService.addWishList(userId, productId));
     }
 
-
+    //위시리스트 조회
+    @GetMapping
+    public ResponseEntity<List<WishList>> getWishList(@AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok().body(wishListService.getWishList(userId));
+    }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
@@ -3,19 +3,12 @@ package com.zerobase.wishmarket.domain.wishList.controller;
 import com.zerobase.wishmarket.common.jwt.JwtAuthenticationProvider;
 import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
 import com.zerobase.wishmarket.domain.wishList.service.WishListService;
-
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/wishlist")
@@ -39,6 +32,15 @@ public class WishListController {
     @GetMapping
     public ResponseEntity<List<WishList>> getWishList(@AuthenticationPrincipal Long userId) {
         return ResponseEntity.ok().body(wishListService.getWishList(userId));
+    }
+
+    //위시리스트 삭제
+    @DeleteMapping
+    public ResponseEntity<Boolean> deleteWishList(@AuthenticationPrincipal Long userId,
+                                                  @RequestParam Long wishListId) {
+        return ResponseEntity.ok()
+                .body(wishListService.deleteWishList(userId, wishListId));
+
     }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
@@ -3,9 +3,12 @@ package com.zerobase.wishmarket.domain.wishList.controller;
 import com.zerobase.wishmarket.common.jwt.JwtAuthenticationProvider;
 import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
 import com.zerobase.wishmarket.domain.wishList.service.WishListService;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,29 +29,12 @@ public class WishListController {
 
     //위시리스트 추가
     @PostMapping("/add")
-    public ResponseEntity<WishList> add(@RequestHeader("Authorization") String token,
-        @RequestParam Long productId) {
-        String userId = provider.getUserId(token);
+    public ResponseEntity<WishList> addWishList(@AuthenticationPrincipal Long userId,
+                                                @RequestParam Long productId) {
         return ResponseEntity.ok()
-            .body(wishListService.addWishList(Long.valueOf(userId), productId));
-    }
-
-    //위시리스트 조회
-    @GetMapping
-    public ResponseEntity<List<WishList>> get(@RequestHeader("Authorization") String token) {
-        String userId = provider.getUserId(token);
-
-        return ResponseEntity.ok().body(wishListService.getWishList(Long.valueOf(userId)));
+                .body(wishListService.addWishList(userId, productId));
     }
 
 
-    //위시리스트 삭제
-    @DeleteMapping
-    public ResponseEntity<Boolean> delete(@RequestHeader("Authorization") String token,
-        @RequestParam Long wishListId) {
-        return ResponseEntity.ok()
-            .body(wishListService.deleteWishList(wishListId));
-
-    }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/exception/WishListErrorCode.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/exception/WishListErrorCode.java
@@ -1,0 +1,19 @@
+package com.zerobase.wishmarket.domain.wishList.exception;
+
+import com.zerobase.wishmarket.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum WishListErrorCode implements ErrorCode {
+    WISHLIST_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당하는 찜하기 목록이 없습니다."),
+    ALREADY_PUT_WISHLIST_PRODUCT(HttpStatus.BAD_REQUEST, "이미 찜목록에 저장한 상품입니다.")
+
+    ;
+
+    private final HttpStatus errorCode;
+    private final String message;
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/exception/WishListErrorCode.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/exception/WishListErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum WishListErrorCode implements ErrorCode {
-    WISHLIST_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당하는 찜하기 목록이 없습니다."),
+    WISHLIST_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당하는 찜목록이 없습니다."),
     ALREADY_PUT_WISHLIST_PRODUCT(HttpStatus.BAD_REQUEST, "이미 찜목록에 저장한 상품입니다.")
 
     ;

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/exception/WishListException.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/exception/WishListException.java
@@ -1,0 +1,15 @@
+package com.zerobase.wishmarket.domain.wishList.exception;
+
+import com.zerobase.wishmarket.exception.GlobalException;
+import lombok.Getter;
+
+@Getter
+public class WishListException extends GlobalException {
+
+    private final WishListErrorCode wishListErrorCode;
+
+    public WishListException(WishListErrorCode errorCode) {
+        super(errorCode);
+        this.wishListErrorCode = errorCode;
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/model/entity/RedisUserWishList.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/model/entity/RedisUserWishList.java
@@ -1,0 +1,24 @@
+package com.zerobase.wishmarket.domain.wishList.model.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.redis.core.RedisHash;
+
+import javax.persistence.Id;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@RedisHash("USER_WISHLIST")
+@Builder
+public class RedisUserWishList {
+
+    @Id
+    private Long id;
+
+    private List<WishList> wishLists;
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/model/entity/WishList.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/model/entity/WishList.java
@@ -1,0 +1,38 @@
+package com.zerobase.wishmarket.domain.wishList.model.entity;
+
+import com.zerobase.wishmarket.entity.BaseEntity;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+import org.springframework.lang.Nullable;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AuditOverride(forClass = BaseEntity.class)
+@Entity
+public class WishList extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long wishListId;
+
+    private Long userId;
+
+    @Nullable
+    private Long fundingId;
+
+    private Long productId;
+
+
+    public Long getProductId(){
+        return this.productId;
+    }
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/model/entity/WishList.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/model/entity/WishList.java
@@ -5,15 +5,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
 import org.springframework.lang.Nullable;
 
 @Builder
 @AllArgsConstructor
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AuditOverride(forClass = BaseEntity.class)
 @Entity
@@ -30,9 +29,5 @@ public class WishList extends BaseEntity {
 
     private Long productId;
 
-
-    public Long getProductId(){
-        return this.productId;
-    }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/repository/RedisUserWishListRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/repository/RedisUserWishListRepository.java
@@ -1,0 +1,7 @@
+package com.zerobase.wishmarket.domain.wishList.repository;
+
+import com.zerobase.wishmarket.domain.wishList.model.entity.RedisUserWishList;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RedisUserWishListRepository extends CrudRepository<RedisUserWishList, Long> {
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/repository/WishListRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/repository/WishListRepository.java
@@ -1,0 +1,13 @@
+package com.zerobase.wishmarket.domain.wishList.repository;
+
+import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WishListRepository extends JpaRepository<WishList, Long> {
+
+    List<WishList> findAllByUserId(Long userId);
+
+    Optional<WishList> findByWishListId(Long wishListId);
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
@@ -6,12 +6,11 @@ import com.zerobase.wishmarket.domain.wishList.model.entity.RedisUserWishList;
 import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
 import com.zerobase.wishmarket.domain.wishList.repository.RedisUserWishListRepository;
 import com.zerobase.wishmarket.domain.wishList.repository.WishListRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-
-import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
@@ -61,6 +60,25 @@ public class WishListService {
         }
 
         return redisUserWishList.get().getWishLists();
+    }
+
+    public boolean deleteWishList(Long userId, Long wishListId) {
+        WishList wishList = wishListRepository.findByWishListId(wishListId)
+                .orElseThrow(() -> new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND));
+
+        RedisUserWishList redisUserWishList = redisUserWishListRepository.findById(userId)
+                .orElseThrow(() -> new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND));
+
+        wishListRepository.delete(wishList);
+
+        //레디스도 업데이트
+        List<WishList> updatedUserWishList = wishListRepository.findAllByUserId(userId);
+        redisUserWishListRepository.save(RedisUserWishList.builder()
+                .id(userId)
+                .wishLists(updatedUserWishList)
+                .build());
+
+        return true;
     }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
@@ -52,6 +52,15 @@ public class WishListService {
         return wishList;
     }
 
+    public List<WishList> getWishList(Long userId) {
+        Optional<RedisUserWishList> redisUserWishList = redisUserWishListRepository.findById(userId);
 
+        //해당 찜목록이 없다면 (사용자의 찜목록에 추가한 상품이 없다면)
+        if (redisUserWishList.isEmpty()) {
+            return null;
+        }
+
+        return redisUserWishList.get().getWishLists();
+    }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
@@ -6,11 +6,10 @@ import com.zerobase.wishmarket.domain.wishList.model.entity.RedisUserWishList;
 import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
 import com.zerobase.wishmarket.domain.wishList.repository.RedisUserWishListRepository;
 import com.zerobase.wishmarket.domain.wishList.repository.WishListRepository;
-import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
@@ -51,16 +50,19 @@ public class WishListService {
         return wishList;
     }
 
+
     public List<WishList> getWishList(Long userId) {
         Optional<RedisUserWishList> redisUserWishList = redisUserWishListRepository.findById(userId);
 
-        //해당 찜목록이 없다면 (사용자의 찜목록에 추가한 상품이 없다면)
+        //아직 생성된 캐쉬가 없는 경우
         if (redisUserWishList.isEmpty()) {
-            return null;
+            return wishListRepository.findAllByUserId(userId);
         }
 
+        //캐쉬가 있는 경우
         return redisUserWishList.get().getWishLists();
     }
+
 
     public boolean deleteWishList(Long userId, Long wishListId) {
         WishList wishList = wishListRepository.findByWishListId(wishListId)

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
@@ -1,0 +1,51 @@
+package com.zerobase.wishmarket.domain.wishList.service;
+
+import com.zerobase.wishmarket.domain.wishList.exception.WishListErrorCode;
+import com.zerobase.wishmarket.domain.wishList.exception.WishListException;
+import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
+import com.zerobase.wishmarket.domain.wishList.repository.WishListRepository;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class WishListService {
+
+    private final WishListRepository wishListRepository;
+
+
+    public WishList addWishList(Long userId, Long productId) {
+
+        //사용자의 찜목록이 존재하는 경우, 이미 추가한 상품인지 확인
+        List<WishList> wishLists = wishListRepository.findAllByUserId(userId);
+
+        if (wishLists.isEmpty()) {
+            for (WishList ws : wishLists) {
+                if (productId == ws.getProductId()) {
+                    throw new WishListException(WishListErrorCode.ALREADY_PUT_WISHLIST_PRODUCT);
+                }
+            }
+        }
+
+        return wishListRepository.save(WishList.builder()
+            .userId(userId)
+            .productId(productId)
+            .build());
+    }
+
+    //페이징 처리 여부 필요
+    //redis 활용 고려
+    public List<WishList> getWishList(Long userId) {
+        return wishListRepository.findAllByUserId(userId);
+    }
+
+
+    public boolean deleteWishList(Long wishListId) {
+        WishList wishList = wishListRepository.findByWishListId(wishListId)
+            .orElseThrow(() -> new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND));
+        wishListRepository.delete(wishList);
+        return true;
+    }
+
+}

--- a/src/test/java/com/zerobase/wishmarket/domain/wishList/service/WishListServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/wishList/service/WishListServiceTest.java
@@ -1,18 +1,20 @@
 package com.zerobase.wishmarket.domain.wishList.service;
 
-import com.zerobase.wishmarket.domain.product.exception.ProductNotFoundException;
-import com.zerobase.wishmarket.domain.product.model.entity.Product;
 import com.zerobase.wishmarket.domain.wishList.exception.WishListErrorCode;
 import com.zerobase.wishmarket.domain.wishList.exception.WishListException;
+import com.zerobase.wishmarket.domain.wishList.model.entity.RedisUserWishList;
 import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
+import com.zerobase.wishmarket.domain.wishList.repository.RedisUserWishListRepository;
 import com.zerobase.wishmarket.domain.wishList.repository.WishListRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.Optional;
 
+@TestPropertySource("classpath:application.properties")
 @SpringBootTest
 class WishListServiceTest {
 
@@ -22,17 +24,22 @@ class WishListServiceTest {
     @Autowired
     private WishListRepository wishListRepository;
 
+    @Autowired
+    private RedisUserWishListRepository redisUserWishListRepository;
+
 
     //찜목록 추가 테스트
     @Test
     void addWishListTest() {
+        //제품Id가 10인 제품을 찜목록에 추가
         wishListService.addWishList(1L, 10L);
 
         Optional<WishList> wishList = wishListRepository.findByWishListId(1L);
         if (wishList.isEmpty()) {
             throw new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND);
         }
-
+        
+        //조회한 찜목록의 제품Id가 10인지 확인
         Assertions.assertEquals(10L, wishList.get().getProductId());
 
     }
@@ -41,10 +48,21 @@ class WishListServiceTest {
     @Test
     void addWishListExceptionTest() {
         wishListService.addWishList(1L, 10L);
-        Assertions.assertThrows(WishListException.class, () ->{
-            wishListService.addWishList(1L,10L);
+        Assertions.assertThrows(WishListException.class, () -> {
+            wishListService.addWishList(1L, 10L);
         });
     }
 
+    //찜목록 조회 테스트
+    @Test
+    void getWishListTest() {
+        //제품Id가 10인 제품을 찜목록에 추가
+        wishListService.addWishList(1L, 10L);
+        RedisUserWishList redisUserWishList = redisUserWishListRepository.findById(1L)
+                .orElseThrow(() -> new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND));
+
+        //redis에 저장된 제품 번호가 10이 맞는지 확인
+        Assertions.assertEquals(10L, redisUserWishList.getWishLists().get(0).getProductId());
+    }
 
 }

--- a/src/test/java/com/zerobase/wishmarket/domain/wishList/service/WishListServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/wishList/service/WishListServiceTest.java
@@ -1,0 +1,50 @@
+package com.zerobase.wishmarket.domain.wishList.service;
+
+import com.zerobase.wishmarket.domain.product.exception.ProductNotFoundException;
+import com.zerobase.wishmarket.domain.product.model.entity.Product;
+import com.zerobase.wishmarket.domain.wishList.exception.WishListErrorCode;
+import com.zerobase.wishmarket.domain.wishList.exception.WishListException;
+import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
+import com.zerobase.wishmarket.domain.wishList.repository.WishListRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+@SpringBootTest
+class WishListServiceTest {
+
+    @Autowired
+    private WishListService wishListService;
+
+    @Autowired
+    private WishListRepository wishListRepository;
+
+
+    //찜목록 추가 테스트
+    @Test
+    void addWishListTest() {
+        wishListService.addWishList(1L, 10L);
+
+        Optional<WishList> wishList = wishListRepository.findByWishListId(1L);
+        if (wishList.isEmpty()) {
+            throw new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND);
+        }
+
+        Assertions.assertEquals(10L, wishList.get().getProductId());
+
+    }
+
+    //찜목록 추가 같은 상품을 넣을시 예외처리 발생 테스트
+    @Test
+    void addWishListExceptionTest() {
+        wishListService.addWishList(1L, 10L);
+        Assertions.assertThrows(WishListException.class, () ->{
+            wishListService.addWishList(1L,10L);
+        });
+    }
+
+
+}

--- a/src/test/java/com/zerobase/wishmarket/domain/wishList/service/WishListServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/wishList/service/WishListServiceTest.java
@@ -38,7 +38,7 @@ class WishListServiceTest {
         if (wishList.isEmpty()) {
             throw new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND);
         }
-        
+
         //조회한 찜목록의 제품Id가 10인지 확인
         Assertions.assertEquals(10L, wishList.get().getProductId());
 
@@ -63,6 +63,24 @@ class WishListServiceTest {
 
         //redis에 저장된 제품 번호가 10이 맞는지 확인
         Assertions.assertEquals(10L, redisUserWishList.getWishLists().get(0).getProductId());
+    }
+
+    //찜목록 삭제 테스트
+    @Test
+    void deleteWishListTest() {
+        //제품을 찜목록에 추가
+        wishListService.addWishList(1L, 1L);
+        wishListService.addWishList(1L, 2L);
+        wishListService.addWishList(1L, 3L);
+
+        //찜목록Id가 1인 찜목록 삭제, 제품Id가 1인 제품이 삭제됨
+        wishListService.deleteWishList(1L, 1L);
+
+        RedisUserWishList redisUserWishList = redisUserWishListRepository.findById(1L)
+                .orElseThrow(() -> new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND));
+
+        Assertions.assertNotEquals(1L,redisUserWishList.getWishLists().get(0).getProductId());
+
     }
 
 }


### PR DESCRIPTION
## 변경사항
1. 모든 컨트롤러는 Header로부터 유저 토큰을 받아 유저 정보를 주입

2. 찜목록 추가
	- 이미 찜목록에 있는 상품인지 확인
		- 있다면 처리 x, exception
	- 없다면 해당 상품을 찜목록에 추가

3. 찜목록 조회
	- 토큰으로 유저 정보 확인
	- 해당 유저의 Id와 같은 찜목록 조회

4. 찜목록 삭제
	- 찜목록Id를 비교 후 삭제

=============================================

5. 찜목록 조회시,

해당하는 캐쉬가 존재하면 캐쉬로 값을 받고

아니라면 직접 조회해서 반환



## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?
