### PR TITLE
feat(User) : 비밀번호 변경 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.zerobase.wishmarket.domain.user.controller;
+
+import com.zerobase.wishmarket.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PutMapping("/password")
+    public ResponseEntity<?> passwordChange(@RequestBody String email, String password) {
+        return ResponseEntity.ok(userService.passwordChange(email, password));
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
@@ -1,12 +1,13 @@
 package com.zerobase.wishmarket.domain.user.controller;
 
+import com.zerobase.wishmarket.domain.user.model.dto.ChangePwdForm;
+import com.zerobase.wishmarket.domain.user.model.type.UserPasswordChangeReturnType;
 import com.zerobase.wishmarket.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 
 @RestController
@@ -17,7 +18,7 @@ public class UserController {
     private final UserService userService;
 
     @PutMapping("/password")
-    public ResponseEntity<?> passwordChange(@RequestBody String email, String password) {
-        return ResponseEntity.ok(userService.passwordChange(email, password));
+    public ResponseEntity<UserPasswordChangeReturnType> passwordChange(@RequestBody @Valid ChangePwdForm form) {
+        return ResponseEntity.ok(userService.passwordChange(form));
     }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/ChangePwdForm.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/ChangePwdForm.java
@@ -1,0 +1,17 @@
+package com.zerobase.wishmarket.domain.user.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+public class ChangePwdForm {
+
+    @NotNull
+    private String email;
+
+    @NotNull
+    private String password;
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/UserDto.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/UserDto.java
@@ -1,6 +1,8 @@
 package com.zerobase.wishmarket.domain.user.model.dto;
 
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.model.type.UserRolesType;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -24,6 +26,23 @@ public class UserDto {
     private String profileImage;
     private UserRegistrationType userRegistrationType;
     private UserStatusType userStatusType;
+    private UserRolesType userRolesType;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
+    public static UserDto from(UserEntity userEntity) {
+        return UserDto.builder()
+                .id(userEntity.getUserId())
+                .name(userEntity.getName())
+                .email(userEntity.getEmail())
+                .nickName(userEntity.getNickName())
+                .phone(userEntity.getPhone())
+                .profileImage(userEntity.getProfileImage())
+                .userRegistrationType(userEntity.getUserRegistrationType())
+                .userStatusType(userEntity.getUserStatusType())
+                .userRolesType(userEntity.getUserRoleType())
+                .createdAt(userEntity.getCreatedAt())
+                .modifiedAt(userEntity.getModifiedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
@@ -5,21 +5,10 @@ import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.model.type.UserRolesType;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import com.zerobase.wishmarket.entity.BaseEntity;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.*;
 
 @Getter
 @Builder
@@ -64,12 +53,12 @@ public class UserEntity extends BaseEntity {
 
     public static UserEntity of(SignUpForm form, UserRegistrationType userRegistrationType) {
         return UserEntity.builder()
-            .name(form.getName())
-            .email(form.getEmail())
-            .nickName(form.getNickName())
-            .password(form.getPassword())
-            .userRegistrationType(userRegistrationType)
-            .build();
+                .name(form.getName())
+                .email(form.getEmail())
+                .nickName(form.getNickName())
+                .password(form.getPassword())
+                .userRegistrationType(userRegistrationType)
+                .build();
     }
 
     public void setUserStatusType(UserStatusType userStatusType) {
@@ -80,7 +69,10 @@ public class UserEntity extends BaseEntity {
         this.name = name;
         this.profileImage = profileImage;
         return this;
+    }
 
+    public void setPassword(String password) {
+        this.password = password;
     }
 
 

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/type/UserPasswordChangeReturnType.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/type/UserPasswordChangeReturnType.java
@@ -1,0 +1,6 @@
+package com.zerobase.wishmarket.domain.user.model.type;
+
+public enum UserPasswordChangeReturnType {
+    CHANGE_PASSWORD_SUCCESS,
+    CHANGE_PASSWORD_FAIL
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.wishmarket.domain.user.repository;
+
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+    Optional<UserEntity> findByEmailAndUserRegistrationType(String email, UserRegistrationType userRegistration);
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserService.java
@@ -1,0 +1,38 @@
+package com.zerobase.wishmarket.domain.user.service;
+
+import com.zerobase.wishmarket.domain.user.exception.UserException;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.USER_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserEntity passwordChange(String email, String password) {
+
+        String encodePassword = passwordEncoder.encode(password);
+        Optional<UserEntity> user = userRepository.findByEmailAndUserRegistrationType(email, UserRegistrationType.EMAIL);
+
+        if (user.isPresent()) {
+            user.get().setPassword(encodePassword);
+            userRepository.save(user.get());
+        } else {
+            throw new UserException(USER_NOT_FOUND);
+        }
+
+        return user.get();
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.zerobase.wishmarket.domain.user.service;
 
 import com.zerobase.wishmarket.domain.user.exception.UserException;
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.repository.UserRepository;
@@ -21,18 +22,19 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public UserEntity passwordChange(String email, String password) {
+    public UserDto passwordChange(String email, String password) {
 
         String encodePassword = passwordEncoder.encode(password);
         Optional<UserEntity> user = userRepository.findByEmailAndUserRegistrationType(email, UserRegistrationType.EMAIL);
 
-        if (user.isPresent()) {
-            user.get().setPassword(encodePassword);
-            userRepository.save(user.get());
-        } else {
+        if (!user.isPresent()) {
             throw new UserException(USER_NOT_FOUND);
+        } else {
+            UserEntity userInfo = user.get();
+            userInfo.setPassword(encodePassword);
+            UserEntity changeUserInfo = userRepository.save(userInfo);
+            return UserDto.from(changeUserInfo);
         }
 
-        return user.get();
     }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserService.java
@@ -1,8 +1,8 @@
 package com.zerobase.wishmarket.domain.user.service;
 
-import com.zerobase.wishmarket.domain.user.exception.UserException;
-import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.dto.ChangePwdForm;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserPasswordChangeReturnType;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.USER_NOT_FOUND;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,18 +20,18 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public UserDto passwordChange(String email, String password) {
+    public UserPasswordChangeReturnType passwordChange(ChangePwdForm form) {
 
-        String encodePassword = passwordEncoder.encode(password);
-        Optional<UserEntity> user = userRepository.findByEmailAndUserRegistrationType(email, UserRegistrationType.EMAIL);
+        String encodePassword = passwordEncoder.encode(form.getPassword());
+        Optional<UserEntity> user = userRepository.findByEmailAndUserRegistrationType(form.getEmail(), UserRegistrationType.EMAIL);
 
         if (!user.isPresent()) {
-            throw new UserException(USER_NOT_FOUND);
+            return UserPasswordChangeReturnType.CHANGE_PASSWORD_FAIL;
         } else {
             UserEntity userInfo = user.get();
             userInfo.setPassword(encodePassword);
-            UserEntity changeUserInfo = userRepository.save(userInfo);
-            return UserDto.from(changeUserInfo);
+            userRepository.save(userInfo);
+            return UserPasswordChangeReturnType.CHANGE_PASSWORD_SUCCESS;
         }
 
     }

--- a/src/test/java/com/zerobase/wishmarket/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.zerobase.wishmarket.domain.user.service;
 
+import com.zerobase.wishmarket.domain.user.model.dto.ChangePwdForm;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.repository.UserRepository;
@@ -13,7 +14,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -53,9 +54,14 @@ class UserServiceTest {
                         .build()));
 
         // when
-        UserEntity user = userService.passwordChange(email, "potato");
+        ChangePwdForm form = ChangePwdForm.builder()
+                .email("test@test.com")
+                .password("potato")
+                .build();
+        userService.passwordChange(form);
 
         // then
-        assertTrue(this.passwordEncoder.matches("potato", user.getPassword()));
+        assertEquals(true, this.passwordEncoder.matches("potato",
+                userRepository.findByEmailAndUserRegistrationType(form.getEmail(), UserRegistrationType.EMAIL).get().getPassword()));
     }
 }

--- a/src/test/java/com/zerobase/wishmarket/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/user/service/UserServiceTest.java
@@ -1,0 +1,61 @@
+package com.zerobase.wishmarket.domain.user.service;
+
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Spy
+    private BCryptPasswordEncoder passwordEncoder;
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void passwordChange() {
+
+        // given
+        String email = "test@test.com";
+        String password = "tomato";
+        String encodePassword = this.passwordEncoder.encode(password);
+        UserRegistrationType userRegistrationType = UserRegistrationType.EMAIL;
+
+        given(userRepository.save(any()))
+                .willReturn(UserEntity.builder()
+                        .userId(1L)
+                        .email(email)
+                        .password(encodePassword)
+                        .userRegistrationType(userRegistrationType)
+                        .build());
+
+        given(userRepository.findByEmailAndUserRegistrationType("test@test.com", UserRegistrationType.EMAIL))
+                .willReturn(Optional.ofNullable(UserEntity.builder()
+                        .userId(1L)
+                        .email(email)
+                        .password(encodePassword)
+                        .userRegistrationType(userRegistrationType)
+                        .build()));
+
+        // when
+        UserEntity user = userService.passwordChange(email, "potato");
+
+        // then
+        assertTrue(this.passwordEncoder.matches("potato", user.getPassword()));
+    }
+}


### PR DESCRIPTION
## 관련이슈
- #25 

## 변경사항
- 해당 기능은 로그인한 유저가 아닌 비밀번호를 찾고자 하는 비로그인 유저(이메일 회원가입 유저)를 대상으로 한 API 입니다.
- 유저의 이메일주소와 변경하고자 하는 비밀번호를 입력받아 해당 유저의 비밀번호를 변경하는 기능입니다.

## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [X]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [X]  모든 **테스트**가 성공했나요?

## 테스트 사항
**1. 테스트 코드를 활용하여 입력받은 비밀번호와 변경된 비밀번호가 일치하는지 테스트한 결과입니다. (비밀번호 암호화 적용)**
![스크린샷 2023-02-19 오전 4 07 03](https://user-images.githubusercontent.com/113086103/219883861-56219db6-f8de-462b-88d5-9029ac6811c4.png)

