### PR TITLE
feat(User) : 회원정보 조회기능 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserController.java
@@ -1,0 +1,24 @@
+package com.zerobase.wishmarket.domain.user.controller;
+
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/detail")
+    public ResponseEntity<?> userDetail(@AuthenticationPrincipal Long userId) {
+        UserDto userInfo = userService.userDetail(userId);
+        return ResponseEntity.ok(userInfo);
+    }
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/UserDto.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/UserDto.java
@@ -1,19 +1,18 @@
 package com.zerobase.wishmarket.domain.user.model.dto;
 
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.model.type.UserRolesType;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
+import lombok.*;
+
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
 @ToString
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class UserDto {
 
     private Long id;
@@ -24,6 +23,23 @@ public class UserDto {
     private String profileImage;
     private UserRegistrationType userRegistrationType;
     private UserStatusType userStatusType;
+    private UserRolesType userRolesType;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
+    public static UserDto from(UserEntity userEntity) {
+        return UserDto.builder()
+                .id(userEntity.getUserId())
+                .name(userEntity.getName())
+                .email(userEntity.getEmail())
+                .nickName(userEntity.getNickName())
+                .phone(userEntity.getPhone())
+                .profileImage(userEntity.getProfileImage())
+                .userRegistrationType(userEntity.getUserRegistrationType())
+                .userStatusType(userEntity.getUserStatusType())
+                .userRolesType(userEntity.getUserRoleType())
+                .createdAt(userEntity.getCreatedAt())
+                .modifiedAt(userEntity.getModifiedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.wishmarket.domain.user.repository;
+
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+    Optional<UserEntity> findByUserId(Long userId);
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/repository/UserRepository.java
@@ -1,6 +1,5 @@
 package com.zerobase.wishmarket.domain.user.repository;
 
-import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserService.java
@@ -1,0 +1,30 @@
+package com.zerobase.wishmarket.domain.user.service;
+
+import com.zerobase.wishmarket.domain.user.exception.UserException;
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.USER_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserDto userDetail(Long userId) {
+        Optional<UserEntity> userInfo = userRepository.findByUserId(userId);
+        if (!userInfo.isPresent()) {
+            throw new UserException(USER_NOT_FOUND);
+        } else {
+            return UserDto.from(userInfo.get());
+        }
+    }
+}

--- a/src/test/java/com/zerobase/wishmarket/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/user/service/UserServiceTest.java
@@ -1,0 +1,53 @@
+package com.zerobase.wishmarket.domain.user.service;
+
+import com.zerobase.wishmarket.domain.user.model.dto.UserDto;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
+import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
+import com.zerobase.wishmarket.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private UserService userService;
+    @Mock
+    private UserDto userInfo;
+    @Mock
+    private Optional<UserEntity> userEntity;
+
+    @Test
+    void userDetail() {
+
+        given(userRepository.findByUserId(1L))
+                .willReturn(Optional.ofNullable(UserEntity.builder()
+                        .userId(1L)
+                        .name("starbucks")
+                        .email("test@test.naver.com")
+                        .nickName("coffee")
+                        .phone("010-1234-5678")
+                        .userRegistrationType(UserRegistrationType.EMAIL)
+                        .userStatusType(UserStatusType.ACTIVE)
+                        .build()));
+
+        userEntity = userRepository.findByUserId(1L);
+        userInfo = userService.userDetail(UserDto.from(userEntity.get()).getId());
+
+        assertEquals(1L, userInfo.getId());
+        assertEquals("coffee", userInfo.getNickName());
+        assertEquals("010-1234-5678", userInfo.getPhone());
+        assertEquals(UserRegistrationType.EMAIL, userInfo.getUserRegistrationType());
+    }
+}


### PR DESCRIPTION
## 관련이슈
- #64 

## 변경사항
- 로그인한 유저의 회원정보를 데이터베이스에서 불러와 전달하는 기능입니다.
- 회원 비밀번호 변경과 마찬가지로 API 명세서상 /api/user 에 해당하는 부분이므로 userAuth~ 가 아닌 user~ 로 구현하였습니다.

## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [X]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [X]  모든 **테스트**가 성공했나요?

## 테스트 결과
![스크린샷 2023-02-20 오전 2 26 18](https://user-images.githubusercontent.com/113086103/219964327-27c087cd-2aa6-4b35-b47f-af863e126eef.png)
