### PR TITLE
feat(Funding): 펀딩 API - 펀딩 참여자에 대한 엔티티 정의

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/domain/funding/model/entity/Funding.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/model/entity/Funding.java
@@ -6,6 +6,8 @@ import com.zerobase.wishmarket.domain.product.model.entity.Product;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.entity.BaseEntity;
 import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -14,11 +16,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.envers.AuditOverride;
 
@@ -29,7 +34,7 @@ import org.hibernate.envers.AuditOverride;
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
 @Entity
-public class Funding extends BaseEntity{
+public class Funding extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,6 +56,9 @@ public class Funding extends BaseEntity{
     @JoinColumn(name = "product_id")
     private Product product;
 
+    @OneToMany(mappedBy = "funding", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<FundingParticipation> participationList;
+
     // 목표 상품 가격
     private Long targetPrice;
 
@@ -66,4 +74,21 @@ public class Funding extends BaseEntity{
     private LocalDateTime startDate;
 
     private LocalDateTime endDate;
+
+    //펀딩된 누적 금액 업데이트
+    public void setFundedPrice(Long fundedPrice, Long fundPrice) {
+        this.fundedPrice = fundedPrice + fundPrice;
+    }
+
+    //내가 친구들한테 준 펀딩 상태 set
+    public void setFundingStatusType(FundingStatusType fundingStatusType) {
+        this.fundingStatusType = fundingStatusType;
+    }
+
+    //받은 펀딩 상태 set
+    private void setFundedStatusType(FundedStatusType fundedStatusType) {
+        this.fundedStatusType = fundedStatusType;
+    }
+
+
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/funding/model/entity/FundingParticipation.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/model/entity/FundingParticipation.java
@@ -1,0 +1,40 @@
+package com.zerobase.wishmarket.domain.funding.model.entity;
+
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class FundingParticipation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "participation_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "funding_id")
+    private Funding funding;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    private Long price;
+
+    private LocalDateTime fundedAt;
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
@@ -3,6 +3,7 @@ package com.zerobase.wishmarket.domain.user.model.entity;
 import com.zerobase.wishmarket.domain.follow.model.entity.Follow;
 import com.zerobase.wishmarket.domain.follow.model.entity.FollowInfo;
 import com.zerobase.wishmarket.domain.funding.model.entity.Funding;
+import com.zerobase.wishmarket.domain.funding.model.entity.FundingParticipation;
 import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.model.type.UserRolesType;
@@ -83,6 +84,9 @@ public class UserEntity extends BaseEntity {
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Funding> fundingList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<FundingParticipation> participationList = new ArrayList<>();
 
     // 회원 가입 시 가입 정보 입력
     public static UserEntity of(SignUpForm form, UserRegistrationType userRegistrationType,


### PR DESCRIPTION
## 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->

펀딩 참여자 엔티티는 펀딩 엔티티와 다대일(N:1) 관계,

유저 엔티티와 다대일(N:1) 관계로 정의하였습니다.

그에 따라 UserEntity, FundingEntity에 대한 정의도 수정하였습니다.



## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
