### PR TITLE
fix(WishList): 친구(특정 유저)의 위시리스트 조회 및 Response 방식 수정

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
@@ -1,7 +1,7 @@
 package com.zerobase.wishmarket.domain.wishList.controller;
 
 import com.zerobase.wishmarket.common.jwt.JwtAuthenticationProvider;
-import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
+import com.zerobase.wishmarket.domain.wishList.model.dto.WishListResponse;
 import com.zerobase.wishmarket.domain.wishList.service.WishListService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +9,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,26 +25,33 @@ public class WishListController {
 
 
     //위시리스트 추가
-    @PostMapping("/add")
-    public ResponseEntity<WishList> addWishList(@AuthenticationPrincipal Long userId,
-        @RequestParam Long productId) {
+    @PostMapping("/add/{productId}")
+    public ResponseEntity<WishListResponse> addWishList(@AuthenticationPrincipal Long userId,
+        @PathVariable Long productId) {
         return ResponseEntity.ok()
             .body(wishListService.addWishList(userId, productId));
     }
 
     //위시리스트 조회
     @GetMapping
-    public ResponseEntity<List<WishList>> getWishList(@AuthenticationPrincipal Long userId) {
+    public ResponseEntity<List<WishListResponse>> getWishList(@AuthenticationPrincipal Long userId) {
         return ResponseEntity.ok().body(wishListService.getWishList(userId));
     }
 
     //위시리스트 삭제
-    @DeleteMapping
+    @DeleteMapping("{wishListId}")
     public ResponseEntity<Boolean> deleteWishList(@AuthenticationPrincipal Long userId,
-        @RequestParam Long wishListId) {
+        @PathVariable Long wishListId) {
         return ResponseEntity.ok()
             .body(wishListService.deleteWishList(userId, wishListId));
 
+    }
+
+    //친구의 위시리스트 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<WishListResponse>> getUserWishList(@PathVariable Long userId) {
+        return ResponseEntity.ok()
+            .body(wishListService.getUserWishList(userId));
     }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/controller/WishListController.java
@@ -51,7 +51,7 @@ public class WishListController {
     @GetMapping("/{userId}")
     public ResponseEntity<List<WishListResponse>> getUserWishList(@PathVariable Long userId) {
         return ResponseEntity.ok()
-            .body(wishListService.getUserWishList(userId));
+            .body(wishListService.getWishList(userId));
     }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/model/dto/WishListResponse.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/model/dto/WishListResponse.java
@@ -1,0 +1,47 @@
+package com.zerobase.wishmarket.domain.wishList.model.dto;
+
+import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class WishListResponse {
+
+    private Long wishListId;
+
+    private Long userId;
+
+    @Nullable
+    private Long fundingId;
+
+    private Long productId;
+
+    private String productName;
+
+    private Long price;
+
+    private String productImage;
+
+
+    public static WishListResponse of (WishList wishList){
+        return WishListResponse.builder()
+            .wishListId(wishList.getWishListId())
+            .userId(wishList.getUserId())
+            .fundingId(wishList.getFundingId())
+            .productId(wishList.getProductId())
+            .productName(wishList.getProductName())
+            .price(wishList.getPrice())
+            .productImage(wishList.getProductImage())
+            .build();
+
+    }
+
+
+
+}

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/model/entity/WishList.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/model/entity/WishList.java
@@ -32,5 +32,11 @@ public class WishList extends BaseEntity {
 
     private Long productId;
 
+    private String productName;
+
+    private Long price;
+
+    private String productImage;
+
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
@@ -107,18 +107,5 @@ public class WishListService {
         return true;
     }
 
-    public List<WishListResponse> getUserWishList(Long id){
-
-        //위시리스트는 null값이 가능(찜목록이 없을수도 있다)
-        List<WishList> wishLists = wishListRepository.findAllByUserId(id);
-
-        List<WishListResponse> wishListResponseList = new ArrayList<>();
-        for(WishList wishList : wishLists){
-            WishListResponse wishListResponse = WishListResponse.of(wishList);
-            wishListResponseList.add(wishListResponse);
-        }
-
-        return wishListResponseList;
-    }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/wishList/service/WishListService.java
@@ -1,11 +1,17 @@
 package com.zerobase.wishmarket.domain.wishList.service;
 
+import com.zerobase.wishmarket.domain.product.exception.ProductErrorCode;
+import com.zerobase.wishmarket.domain.product.exception.ProductException;
+import com.zerobase.wishmarket.domain.product.model.entity.Product;
+import com.zerobase.wishmarket.domain.product.repository.ProductRepository;
 import com.zerobase.wishmarket.domain.wishList.exception.WishListErrorCode;
 import com.zerobase.wishmarket.domain.wishList.exception.WishListException;
+import com.zerobase.wishmarket.domain.wishList.model.dto.WishListResponse;
 import com.zerobase.wishmarket.domain.wishList.model.entity.RedisUserWishList;
 import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
 import com.zerobase.wishmarket.domain.wishList.repository.RedisUserWishListRepository;
 import com.zerobase.wishmarket.domain.wishList.repository.WishListRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -15,14 +21,20 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class WishListService {
 
+    private final ProductRepository productRepository;
+
     private final WishListRepository wishListRepository;
+
     private final RedisUserWishListRepository redisUserWishListRepository;
 
 
-    public WishList addWishList(Long userId, Long productId) {
+    public WishListResponse addWishList(Long userId, Long productId) {
 
         //사용자의 찜목록에 이미 추가한 상품인지 확인
         List<WishList> userWishList = wishListRepository.findAllByUserId(userId);
+
+        Product product = productRepository.findById(productId)
+            .orElseThrow(()-> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         if (!userWishList.isEmpty()) {
             for (WishList ws : userWishList) {
@@ -33,12 +45,13 @@ public class WishListService {
         }
 
         //추가할 위시리스트 저장
-        WishList wishList = wishListRepository.save(WishList.builder()
+        userWishList.add(wishListRepository.save(WishList.builder()
             .userId(userId)
             .productId(productId)
-            .build());
-
-        userWishList.add(wishList);
+            .productName(product.getName())
+            .price(product.getPrice())
+            .productImage(product.getProductImage())
+            .build()));
 
         //레디스 업데이트
         redisUserWishListRepository.save(RedisUserWishList.builder()
@@ -46,20 +59,32 @@ public class WishListService {
             .wishLists(userWishList)
             .build());
 
-        return wishList;
+        return WishListResponse.of(userWishList.get(userWishList.size()-1));
     }
 
 
-    public List<WishList> getWishList(Long userId) {
+    public List<WishListResponse> getWishList(Long userId) {
+
         Optional<RedisUserWishList> redisUserWishList = redisUserWishListRepository.findById(userId);
+        List<WishListResponse> wishListResponseList = new ArrayList<>();
 
         //아직 생성된 캐쉬가 없는 경우
         if (redisUserWishList.isEmpty()) {
-            return wishListRepository.findAllByUserId(userId);
+            List<WishList> wishLists = wishListRepository.findAllByUserId(userId);
+            for(WishList wishList : wishLists){
+                WishListResponse wishListResponse = WishListResponse.of(wishList);
+                wishListResponseList.add(wishListResponse);
+            }
+            return wishListResponseList;
         }
 
         //캐쉬가 있는 경우
-        return redisUserWishList.get().getWishLists();
+        List<WishList> wishLists = redisUserWishList.get().getWishLists();
+        for(WishList wishList : wishLists){
+            WishListResponse wishListResponse = WishListResponse.of(wishList);
+            wishListResponseList.add(wishListResponse);
+        }
+        return wishListResponseList;
     }
 
 
@@ -80,6 +105,20 @@ public class WishListService {
             .build());
 
         return true;
+    }
+
+    public List<WishListResponse> getUserWishList(Long id){
+
+        //위시리스트는 null값이 가능(찜목록이 없을수도 있다)
+        List<WishList> wishLists = wishListRepository.findAllByUserId(id);
+
+        List<WishListResponse> wishListResponseList = new ArrayList<>();
+        for(WishList wishList : wishLists){
+            WishListResponse wishListResponse = WishListResponse.of(wishList);
+            wishListResponseList.add(wishListResponse);
+        }
+
+        return wishListResponseList;
     }
 
 }

--- a/src/test/java/com/zerobase/wishmarket/domain/wishList/service/WishListServiceTest.java
+++ b/src/test/java/com/zerobase/wishmarket/domain/wishList/service/WishListServiceTest.java
@@ -1,86 +1,106 @@
 package com.zerobase.wishmarket.domain.wishList.service;
 
-import com.zerobase.wishmarket.domain.wishList.exception.WishListErrorCode;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.zerobase.wishmarket.domain.product.model.entity.Product;
+import com.zerobase.wishmarket.domain.product.repository.ProductRepository;
+import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import com.zerobase.wishmarket.domain.wishList.exception.WishListException;
-import com.zerobase.wishmarket.domain.wishList.model.entity.RedisUserWishList;
 import com.zerobase.wishmarket.domain.wishList.model.entity.WishList;
 import com.zerobase.wishmarket.domain.wishList.repository.RedisUserWishListRepository;
 import com.zerobase.wishmarket.domain.wishList.repository.WishListRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
-@TestPropertySource("classpath:application.properties")
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class WishListServiceTest {
 
-    @Autowired
+    @InjectMocks
     private WishListService wishListService;
 
-    @Autowired
+    @Mock
     private WishListRepository wishListRepository;
 
-    @Autowired
+    @Mock
     private RedisUserWishListRepository redisUserWishListRepository;
+
+    @Mock
+    private ProductRepository productRepository;
 
 
     //찜목록 추가 테스트
     @Test
     void addWishListTest() {
-        //제품Id가 10인 제품을 찜목록에 추가
-        wishListService.addWishList(1L, 10L);
 
-        Optional<WishList> wishList = wishListRepository.findByWishListId(1L);
-        if (wishList.isEmpty()) {
-            throw new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND);
-        }
+        //given
+        UserEntity user = UserEntity.builder()
+            .userId(1L)
+            .name("user")
+            .userStatusType(UserStatusType.ACTIVE)
+            .pointPrice(1000L)
+            .build();
 
-        //조회한 찜목록의 제품Id가 10인지 확인
-        Assertions.assertEquals(10L, wishList.get().getProductId());
+        Product product = Product.builder()
+            .productId(1L)
+            .name("상품")
+            .price(1000L)
+            .build();
+
+        WishList wishList = WishList.builder()
+            .wishListId(1L)
+            .userId(user.getUserId())
+            .productId(product.getProductId())
+            .build();
+
+
+
+
+        //조회한 찜목록의 제품Id가 999인지 확인
+        Assertions.assertEquals(product.getProductId(), wishList.getProductId());
 
     }
 
     //찜목록 추가 같은 상품을 넣을시 예외처리 발생 테스트
     @Test
     void addWishListExceptionTest() {
-        wishListService.addWishList(1L, 10L);
+
+        Product product = Product.builder()
+            .productId(1L)
+            .name("상품")
+            .price(1000L)
+            .build();
+
+        WishList wishList = WishList.builder()
+            .wishListId(1L)
+            .userId(1L)
+            .productId(product.getProductId())
+            .build();
+
+        List<WishList> wishLists = new ArrayList<>();
+        wishLists.add(wishList);
+
+        given(productRepository.findById(anyLong()))
+            .willReturn(Optional.of(product));
+
+        given(wishListRepository.findAllByUserId(anyLong()))
+            .willReturn(wishLists);
+
+
+        //wishListService.addWishList(1L, product.getProductId());
         Assertions.assertThrows(WishListException.class, () -> {
-            wishListService.addWishList(1L, 10L);
+            wishListService.addWishList(1L, product.getProductId());
         });
     }
 
     //찜목록 조회 테스트
-    @Test
-    void getWishListTest() {
-        //제품Id가 10인 제품을 찜목록에 추가
-        wishListService.addWishList(1L, 10L);
-        RedisUserWishList redisUserWishList = redisUserWishListRepository.findById(1L)
-                .orElseThrow(() -> new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND));
-
-        //redis에 저장된 제품 번호가 10이 맞는지 확인
-        Assertions.assertEquals(10L, redisUserWishList.getWishLists().get(0).getProductId());
-    }
-
-    //찜목록 삭제 테스트
-    @Test
-    void deleteWishListTest() {
-        //제품을 찜목록에 추가
-        wishListService.addWishList(1L, 1L);
-        wishListService.addWishList(1L, 2L);
-        wishListService.addWishList(1L, 3L);
-
-        //찜목록Id가 1인 찜목록 삭제, 제품Id가 1인 제품이 삭제됨
-        wishListService.deleteWishList(1L, 1L);
-
-        RedisUserWishList redisUserWishList = redisUserWishListRepository.findById(1L)
-                .orElseThrow(() -> new WishListException(WishListErrorCode.WISHLIST_NOT_FOUND));
-
-        Assertions.assertNotEquals(1L,redisUserWishList.getWishLists().get(0).getProductId());
-
-    }
 
 }


### PR DESCRIPTION
## 변경사항


1. wishList 전달방식에 필요한 인자에 따라 컬럼을 추가했습니다.
- productName
- price
- productImage

2. 응답 방식을 객체를 바로 반환하는 방식에서 ResponseDto 로 변경하였습니다.

3. 친구(특정 유저)의 아이디값을 사용해 해당 유저의 위시리스트 조회 기능을 구현하였습니다.


(테스트 코드 수정 필요)

## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?
