### PR TITLE
fix(User) : 회원탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/domain/funding/model/entity/Funding.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/model/entity/Funding.java
@@ -6,7 +6,6 @@ import com.zerobase.wishmarket.domain.product.model.entity.Product;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.entity.BaseEntity;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -43,11 +42,13 @@ public class Funding extends BaseEntity {
     private Long id;
 
     // N : 1
+    // 펀딩을 시작한 사람
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity user;
 
     // N : 1
+    // 펀딩을 받는 사람
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "target_id")
     private UserEntity targetUser;
@@ -83,6 +84,16 @@ public class Funding extends BaseEntity {
 
     public void participationPlus() {
         this.participationCount = this.participationCount + 1;
+    }
+
+    // 펀딩 시작유저 탈퇴 시 null 변경
+    public void setStartUserWithdrawal(){
+        this.user = null;
+    }
+
+    // 펀딩 대상유저 탈퇴 시 null 변경
+    public void setTargetUserWithdrawal(){
+        this.targetUser = null;
     }
 
     //펀딩된 누적 금액 업데이트

--- a/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserAuthController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/controller/UserAuthController.java
@@ -66,7 +66,7 @@ public class UserAuthController {
         return ResponseEntity.ok(userAuthService.logout(userId, accessToken));
     }
 
-    @PatchMapping("/withdrawal")
+    @DeleteMapping("/withdrawal")
     public UserWithdrawalReturnType withdrawal(@AuthenticationPrincipal Long userId,
                                                @RequestHeader(name = "Authorization") String accessToken) {
         return userAuthService.withdrawal(userId, accessToken);

--- a/src/main/java/com/zerobase/wishmarket/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/exception/UserErrorCode.java
@@ -18,6 +18,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 회원입니다."),
     EMAIL_NOT_FOUND(BAD_REQUEST, "존재하지 않는 Email 입니다."),
     PASSWORD_DO_NOT_MATCH(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    CANNOT_WITHDRAW_YOU_ARE_TARGET_TO_ONGOING_FUNDING(HttpStatus.BAD_REQUEST, "진행중인 펀딩의 대상일 경우 탈퇴할 수 없습니다."),
+    YOUR_GIFT_HAS_NOT_BEEN_PROCESSED(HttpStatus.BAD_REQUEST, "받은 선물함 중 미수령한 선물이 있을 경우 탈퇴할 수 없습니다.")
 
     ;
 

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/entity/UserEntity.java
@@ -2,32 +2,19 @@ package com.zerobase.wishmarket.domain.user.model.entity;
 
 import com.zerobase.wishmarket.domain.follow.model.entity.Follow;
 import com.zerobase.wishmarket.domain.follow.model.entity.FollowInfo;
+import com.zerobase.wishmarket.domain.funding.model.entity.Funding;
 import com.zerobase.wishmarket.domain.funding.model.entity.FundingParticipation;
 import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.model.type.UserRolesType;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import com.zerobase.wishmarket.entity.BaseEntity;
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import org.hibernate.envers.AuditOverride;
 
 @Getter
 @Builder
@@ -71,7 +58,13 @@ public class UserEntity extends BaseEntity {
     @JoinColumn(name = "delivery_id")
     private DeliveryAddress deliveryAddress;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<Funding> fundingList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "targetUser", fetch = FetchType.LAZY)
+    private List<Funding> fundingTargetList = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(nullable = true)
     private FollowInfo followInfo;
 
@@ -86,18 +79,18 @@ public class UserEntity extends BaseEntity {
 
     // 회원 가입 시 가입 정보 입력
     public static UserEntity of(SignUpForm form, UserRegistrationType userRegistrationType,
-        UserStatusType userStatusType, FollowInfo followInfo) {
+                                UserStatusType userStatusType, FollowInfo followInfo) {
 
         return UserEntity.builder()
-            .name(form.getName())
-            .email(form.getEmail())
-            .nickName(form.getNickName())
-            .password(form.getPassword())
-            .pointPrice(0L)
-            .userRegistrationType(userRegistrationType)
-            .userStatusType(userStatusType)
-            .followInfo(followInfo)
-            .build();
+                .name(form.getName())
+                .email(form.getEmail())
+                .nickName(form.getNickName())
+                .password(form.getPassword())
+                .pointPrice(0L)
+                .userRegistrationType(userRegistrationType)
+                .userStatusType(userStatusType)
+                .followInfo(followInfo)
+                .build();
 
     }
 

--- a/src/main/java/com/zerobase/wishmarket/domain/user/service/UserAuthService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/service/UserAuthService.java
@@ -1,51 +1,42 @@
 package com.zerobase.wishmarket.domain.user.service;
 
-import static com.zerobase.wishmarket.common.jwt.model.constants.JwtConstants.ACCESS_REFRESH_TOKEN_REISSUE_TIME;
-import static com.zerobase.wishmarket.common.jwt.model.constants.JwtConstants.ACCESS_TOKEN_BLACK_LIST_PREFIX;
-import static com.zerobase.wishmarket.common.jwt.model.constants.JwtConstants.ACCESS_TOKEN_PREFIX;
-import static com.zerobase.wishmarket.common.jwt.model.constants.JwtConstants.REFRESH_TOKEN_PREFIX;
-import static com.zerobase.wishmarket.domain.authcode.exception.AuthErrorCode.INVALID_AUTH_CODE;
-import static com.zerobase.wishmarket.domain.authcode.model.constants.AuthCodeProperties.KEY_PREFIX;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.EMAIL_NOT_FOUND;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.INVALID_PASSWORD_FORMAT;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.PASSWORD_DO_NOT_MATCH;
-import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.USER_NOT_FOUND;
-import static com.zerobase.wishmarket.exception.CommonErrorCode.EXPIRED_KEY;
-import static com.zerobase.wishmarket.exception.CommonErrorCode.EXPIRED_REFRESH_TOKEN;
-import static com.zerobase.wishmarket.exception.CommonErrorCode.INVALID_TOKEN;
-import static com.zerobase.wishmarket.exception.CommonErrorCode.NOT_EXPIRED_ACCESS_TOKEN;
-
 import com.zerobase.wishmarket.common.jwt.JwtAuthenticationProvider;
 import com.zerobase.wishmarket.common.jwt.model.dto.TokenSetDto;
 import com.zerobase.wishmarket.common.redis.RedisClient;
 import com.zerobase.wishmarket.domain.authcode.exception.AuthException;
 import com.zerobase.wishmarket.domain.follow.model.entity.FollowInfo;
 import com.zerobase.wishmarket.domain.follow.repository.FollowInfoRepository;
+import com.zerobase.wishmarket.domain.funding.model.entity.Funding;
+import com.zerobase.wishmarket.domain.funding.model.type.FundedStatusType;
+import com.zerobase.wishmarket.domain.funding.repository.FundingRepository;
 import com.zerobase.wishmarket.domain.user.annotation.LoginUserInfo;
 import com.zerobase.wishmarket.domain.user.exception.UserException;
-import com.zerobase.wishmarket.domain.user.model.dto.LogoutResponse;
-import com.zerobase.wishmarket.domain.user.model.dto.OAuthUserInfo;
-import com.zerobase.wishmarket.domain.user.model.dto.ReissueResponse;
-import com.zerobase.wishmarket.domain.user.model.dto.SignInForm;
-import com.zerobase.wishmarket.domain.user.model.dto.SignInResponse;
-import com.zerobase.wishmarket.domain.user.model.dto.SignUpEmailResponse;
-import com.zerobase.wishmarket.domain.user.model.dto.SignUpForm;
+import com.zerobase.wishmarket.domain.user.model.dto.*;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
 import com.zerobase.wishmarket.domain.user.model.type.UserRegistrationType;
 import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import com.zerobase.wishmarket.domain.user.model.type.UserWithdrawalReturnType;
 import com.zerobase.wishmarket.domain.user.repository.UserAuthRepository;
 import com.zerobase.wishmarket.exception.GlobalException;
-import java.util.Date;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static com.zerobase.wishmarket.common.jwt.model.constants.JwtConstants.*;
+import static com.zerobase.wishmarket.domain.authcode.exception.AuthErrorCode.INVALID_AUTH_CODE;
+import static com.zerobase.wishmarket.domain.authcode.model.constants.AuthCodeProperties.KEY_PREFIX;
+import static com.zerobase.wishmarket.domain.funding.model.type.FundingStatusType.ING;
+import static com.zerobase.wishmarket.domain.user.exception.UserErrorCode.*;
+import static com.zerobase.wishmarket.exception.CommonErrorCode.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -74,7 +65,7 @@ public class UserAuthService {
         // 한번 탈퇴했던 회원이라면
         // UserStatus : withdrawal -> active
         Optional<UserEntity> optionalUser = userAuthRepository.findByEmailAndUserRegistrationType(form.getEmail(),
-            UserRegistrationType.EMAIL);
+                UserRegistrationType.EMAIL);
 
         if (optionalUser.isPresent()) {
 
@@ -89,29 +80,29 @@ public class UserAuthService {
         }
 
         form.setPassword(this.passwordEncoder.encode(form.getPassword()));
-        
+
         FollowInfo empthFollowInfo = FollowInfo.builder()
-            .followerCount(0L)
-            .followCount(0L)
-            .build();
+                .followerCount(0L)
+                .followCount(0L)
+                .build();
 
         followInfoRepository.save(empthFollowInfo);
 
         redisClient.del(key);
 
         return SignUpEmailResponse.from(
-            userAuthRepository.save(
-                UserEntity.of(form, UserRegistrationType.EMAIL, UserStatusType.ACTIVE, empthFollowInfo))
+                userAuthRepository.save(
+                        UserEntity.of(form, UserRegistrationType.EMAIL, UserStatusType.ACTIVE, empthFollowInfo))
         );
     }
 
     @Transactional
     public SignInResponse signInEmail(SignInForm form) {
         UserEntity user = userAuthRepository.findByEmailAndUserRegistrationType(
-                form.getEmail(),
-                UserRegistrationType.EMAIL
-            )
-            .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
+                        form.getEmail(),
+                        UserRegistrationType.EMAIL
+                )
+                .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
 
         validationPassword(form.getPassword(), user);
 
@@ -122,28 +113,28 @@ public class UserAuthService {
 
         // redis에 refresh토큰 저장
         redisClient.put(
-            REFRESH_TOKEN_PREFIX + user.getUserId(),
-            tokenSetDto.getRefreshToken(),
-            TimeUnit.SECONDS,
-            expirationSeconds);
+                REFRESH_TOKEN_PREFIX + user.getUserId(),
+                tokenSetDto.getRefreshToken(),
+                TimeUnit.SECONDS,
+                expirationSeconds);
 
         return SignInResponse.builder()
-            .email(user.getEmail())
-            .name(user.getName())
-            .accessToken(ACCESS_TOKEN_PREFIX + tokenSetDto.getAccessToken())
-            .accessTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getAccessToken())))
-            .refreshToken(tokenSetDto.getRefreshToken())
-            .refreshTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getRefreshToken())))
-            .build();
+                .email(user.getEmail())
+                .name(user.getName())
+                .accessToken(ACCESS_TOKEN_PREFIX + tokenSetDto.getAccessToken())
+                .accessTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getAccessToken())))
+                .refreshToken(tokenSetDto.getRefreshToken())
+                .refreshTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getRefreshToken())))
+                .build();
     }
 
     @Transactional
     public SignInResponse signInGoogle(@LoginUserInfo OAuthUserInfo userInfo) {
         UserEntity user = userAuthRepository.findByEmailAndUserRegistrationType(
-                userInfo.getEmail(),
-                UserRegistrationType.GOOGLE
-            )
-            .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
+                        userInfo.getEmail(),
+                        UserRegistrationType.GOOGLE
+                )
+                .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
 
         TokenSetDto tokenSetDto = jwtProvider.generateTokenSet(user.getUserId());
 
@@ -152,28 +143,28 @@ public class UserAuthService {
 
         // redis에 refresh토큰 저장
         redisClient.put(
-            REFRESH_TOKEN_PREFIX + user.getUserId(),
-            tokenSetDto.getRefreshToken(),
-            TimeUnit.SECONDS,
-            expirationSeconds);
+                REFRESH_TOKEN_PREFIX + user.getUserId(),
+                tokenSetDto.getRefreshToken(),
+                TimeUnit.SECONDS,
+                expirationSeconds);
 
         return SignInResponse.builder()
-            .email(user.getEmail())
-            .name(user.getName())
-            .accessToken(ACCESS_TOKEN_PREFIX + tokenSetDto.getAccessToken())
-            .accessTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getAccessToken())))
-            .refreshToken(tokenSetDto.getRefreshToken())
-            .refreshTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getRefreshToken())))
-            .build();
+                .email(user.getEmail())
+                .name(user.getName())
+                .accessToken(ACCESS_TOKEN_PREFIX + tokenSetDto.getAccessToken())
+                .accessTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getAccessToken())))
+                .refreshToken(tokenSetDto.getRefreshToken())
+                .refreshTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getRefreshToken())))
+                .build();
     }
 
     @Transactional
     public SignInResponse signInNaver(@LoginUserInfo OAuthUserInfo userInfo) {
         UserEntity user = userAuthRepository.findByEmailAndUserRegistrationType(
-                userInfo.getEmail(),
-                UserRegistrationType.NAVER
-            )
-            .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
+                        userInfo.getEmail(),
+                        UserRegistrationType.NAVER
+                )
+                .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
 
         TokenSetDto tokenSetDto = jwtProvider.generateTokenSet(user.getUserId());
 
@@ -182,19 +173,19 @@ public class UserAuthService {
 
         // redis에 refresh토큰 저장
         redisClient.put(
-            REFRESH_TOKEN_PREFIX + user.getUserId(),
-            tokenSetDto.getRefreshToken(),
-            TimeUnit.SECONDS,
-            expirationSeconds);
+                REFRESH_TOKEN_PREFIX + user.getUserId(),
+                tokenSetDto.getRefreshToken(),
+                TimeUnit.SECONDS,
+                expirationSeconds);
 
         return SignInResponse.builder()
-            .email(user.getEmail())
-            .name(user.getName())
-            .accessToken(ACCESS_TOKEN_PREFIX + tokenSetDto.getAccessToken())
-            .accessTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getAccessToken())))
-            .refreshToken(tokenSetDto.getRefreshToken())
-            .refreshTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getRefreshToken())))
-            .build();
+                .email(user.getEmail())
+                .name(user.getName())
+                .accessToken(ACCESS_TOKEN_PREFIX + tokenSetDto.getAccessToken())
+                .accessTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getAccessToken())))
+                .refreshToken(tokenSetDto.getRefreshToken())
+                .refreshTokenExpiredAt(String.valueOf(jwtProvider.getExpiredDate(tokenSetDto.getRefreshToken())))
+                .build();
 
     }
 
@@ -215,15 +206,14 @@ public class UserAuthService {
         long expirationSeconds = (jwtProvider.getExpiredDate(accessToken).getTime() - new Date().getTime()) / 1000;
         if (expirationSeconds > 0) {
             redisClient.put(ACCESS_TOKEN_BLACK_LIST_PREFIX + accessToken, String.valueOf(userId), TimeUnit.SECONDS,
-                expirationSeconds);
+                    expirationSeconds);
         }
 
         return LogoutResponse.builder()
-            .message(LOGOUT_MESSAGE)
-            .build();
+                .message(LOGOUT_MESSAGE)
+                .build();
     }
 
-    @Transactional
     public UserWithdrawalReturnType withdrawal(Long userId, String accessToken) {
 
         Optional<UserEntity> userEntity = userAuthRepository.findById(userId);
@@ -233,29 +223,61 @@ public class UserAuthService {
         } else if (ObjectUtils.isEmpty(accessToken) || !(accessToken.startsWith(ACCESS_TOKEN_PREFIX))) {
             return UserWithdrawalReturnType.WITHDRAWAL_FAIL;
         } else {
-            // 로그인한 유저의 userId 와 일치하는 Entity 의 StatusType 변경 및 저장
-            userEntity.get().setUserStatusType(UserStatusType.WITHDRAWAL);
-            userAuthRepository.save(userEntity.get());
 
-            if (!ObjectUtils.isEmpty(accessToken) && accessToken.startsWith(ACCESS_TOKEN_PREFIX)) {
-                accessToken = accessToken.substring(ACCESS_TOKEN_PREFIX.length());
+            List<Funding> fundingList = userEntity.get().getFundingList();
+            List<Funding> targetList = userEntity.get().getFundingTargetList();
+
+            for (int i = 0; i < fundingList.size(); i++) {
+                // 펀딩의 시작한 사람이 탈퇴하려는 유저인 경우
+                // 펀딩이 진행중이건 종료되었건 관계 X
+                if (fundingList.get(i).getUser().getUserId() == userEntity.get().getUserId()) {
+                    // 시작한 사람을 Null 로 변경하고 연관관계 해제
+                    fundingList.get(i).setStartUserWithdrawal();
+                }
             }
 
-            // Redis에서 해당 User id로 저장된 Refresh Token 이 있는지 여부를 확인 후에 있을 경우 삭제를 한다.
-            if (redisClient.getRefreshToken(REFRESH_TOKEN_PREFIX + userId) != null) {
-                // Refresh Token을 삭제
-                redisClient.del(REFRESH_TOKEN_PREFIX + userId);
+            for (int i = 0; i < targetList.size(); i++) {
+                // 탈퇴하려는 유저가 펀딩의 target 인 경우
+                if (userEntity.get().getUserId() == targetList.get(i).getTargetUser().getUserId()) {
+                    // 펀딩이 진행중이면 탈퇴 불가
+                    if (ING.equals(targetList.get(i).getFundingStatusType())) {
+                        throw new UserException(CANNOT_WITHDRAW_YOU_ARE_TARGET_TO_ONGOING_FUNDING);
+                    }
+                    // 탈퇴하려는 유저가 받은 선물 리스트 중 배송지를 입력하지 않은 상품이 있는 경우 탈퇴 불가
+                    else if (!targetList.get(i).getFundingStatusType().equals(ING) &&
+                            !targetList.get(i).getFundedStatusType().equals(FundedStatusType.COMPLETION)) {
+                        throw new UserException(YOUR_GIFT_HAS_NOT_BEEN_PROCESSED);
+                    }
+                    // 종료된 펀딩이면서 배송지 입력까지 마쳤을 경우 탈퇴 가능
+                    else if (!targetList.get(i).getFundingStatusType().equals(ING) &&
+                            targetList.get(i).getFundedStatusType().equals(FundedStatusType.COMPLETION)) {
+                        targetList.get(i).setTargetUserWithdrawal();
+                    }
+                }
             }
-
-            // 해당 Access Token 유효시간을 가지고 와서 BlackList에 저장하기
-            long expirationSeconds = (jwtProvider.getExpiredDate(accessToken).getTime() - new Date().getTime()) / 1000;
-            if (expirationSeconds > 0) {
-                redisClient.put(ACCESS_TOKEN_BLACK_LIST_PREFIX + accessToken, String.valueOf(userId), TimeUnit.SECONDS,
-                    expirationSeconds);
-            }
-
-            return UserWithdrawalReturnType.WITHDRAWAL_SUCCESS;
         }
+
+        // 로그인한 유저의 userId 와 일치하는 Entity 삭제
+        userAuthRepository.delete(userEntity.get());
+
+        if (!ObjectUtils.isEmpty(accessToken) && accessToken.startsWith(ACCESS_TOKEN_PREFIX)) {
+            accessToken = accessToken.substring(ACCESS_TOKEN_PREFIX.length());
+        }
+
+        // Redis에서 해당 User id로 저장된 Refresh Token 이 있는지 여부를 확인 후에 있을 경우 삭제를 한다.
+        if (redisClient.getRefreshToken(REFRESH_TOKEN_PREFIX + userId) != null) {
+            // Refresh Token을 삭제
+            redisClient.del(REFRESH_TOKEN_PREFIX + userId);
+        }
+
+        // 해당 Access Token 유효시간을 가지고 와서 BlackList에 저장하기
+        long expirationSeconds = (jwtProvider.getExpiredDate(accessToken).getTime() - new Date().getTime()) / 1000;
+        if (expirationSeconds > 0) {
+            redisClient.put(ACCESS_TOKEN_BLACK_LIST_PREFIX + accessToken, String.valueOf(userId), TimeUnit.SECONDS,
+                    expirationSeconds);
+        }
+
+        return UserWithdrawalReturnType.WITHDRAWAL_SUCCESS;
     }
 
     public ReissueResponse reissue(String accessToken, String refreshToken) {
@@ -272,7 +294,7 @@ public class UserAuthService {
         Long userId = Long.valueOf(jwtProvider.getUserId(accessToken));
 
         UserEntity user = userAuthRepository.findById(userId)
-            .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         // 1. Refresh Token 유효성 검사
         // 1-1. 유효하지 않거나 만료된 Refresh Token 일 시 Error Response
@@ -288,11 +310,11 @@ public class UserAuthService {
         TokenSetDto tokenSetDto = jwtProvider.generateAccessToken(user.getUserId());
 
         ReissueResponse reissueResponse = ReissueResponse.builder()
-            .email(user.getEmail())
-            .name(user.getName())
-            .accessToken(tokenSetDto.getAccessToken())
-            .accessTokenExpiredAt(String.valueOf(tokenSetDto.getAccessTokenExpiredAt()))
-            .build();
+                .email(user.getEmail())
+                .name(user.getName())
+                .accessToken(tokenSetDto.getAccessToken())
+                .accessTokenExpiredAt(String.valueOf(tokenSetDto.getAccessTokenExpiredAt()))
+                .build();
 
         // 3. 현재시간과 Refresh Token의 만료일을 통해 남은 만료기간 계산
         long now = new Date().getTime();
@@ -303,13 +325,13 @@ public class UserAuthService {
         if (refreshExpireTime - now < ACCESS_REFRESH_TOKEN_REISSUE_TIME) {
             tokenSetDto = jwtProvider.generateTokenSet(user.getUserId());
             reissueResponse = ReissueResponse.builder()
-                .email(user.getEmail())
-                .name(user.getName())
-                .accessToken(tokenSetDto.getAccessToken())
-                .accessTokenExpiredAt(String.valueOf(tokenSetDto.getAccessTokenExpiredAt()))
-                .refreshToken(tokenSetDto.getRefreshToken())
-                .refreshTokenExpiredAt(String.valueOf(tokenSetDto.getRefreshTokenExpiredAt()))
-                .build();
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .accessToken(tokenSetDto.getAccessToken())
+                    .accessTokenExpiredAt(String.valueOf(tokenSetDto.getAccessTokenExpiredAt()))
+                    .refreshToken(tokenSetDto.getRefreshToken())
+                    .refreshTokenExpiredAt(String.valueOf(tokenSetDto.getRefreshTokenExpiredAt()))
+                    .build();
         }
 
         return reissueResponse;
@@ -342,8 +364,8 @@ public class UserAuthService {
     // 유저 Email + 가입 방식을 기반으로 중복 확인
     private boolean isEmailExist(String email) {
         return userAuthRepository.existsByEmailAndUserRegistrationType(
-            email,
-            UserRegistrationType.EMAIL);
+                email,
+                UserRegistrationType.EMAIL);
     }
 
     private boolean checkInvalidPassword(String password) {


### PR DESCRIPTION
## 관련이슈
- #105 

## 변경사항
- 연관관계 매핑 변경
- 회원탈퇴 시 유저 데이터 setNull 후 컬럼 삭제

> ### 회원탈퇴 로직
> 탈퇴하려는 유저가
> 1. 펀딩을 시작한 유저인 경우 : 펀딩 진행여부와 상관없이 펀딩 시작한 user 를 setNull 후 탈퇴
> 2. Target 유저인 경우
>   2-1) target 으로 지정되어 진행중인 펀딩이 있을 경우 탈퇴 불가
>   2-2) target 으로 지정된 펀딩이 종료됐을 경우 탈퇴
> 3. 펀딩이 종료됐어도 받은 선물함에서 주소지 입력 후 수령까지 완료하지 않은 선물이 있을 경우 탈퇴 불가

## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [X]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [X]  모든 **테스트**가 성공했나요?

## 테스트 결과
1. Target 으로 진행중인 선물이 있을 경우
<img width="510" alt="진행중" src="https://user-images.githubusercontent.com/113086103/221441148-b7b13aed-3d4c-4925-bf46-98fce001cc5d.png">

2. 받은 선물함에서 수령하지 않은 선물이 있을 경우 
<img width="584" alt="미수령 진또" src="https://user-images.githubusercontent.com/113086103/221441184-b0dff972-2198-4441-b11f-7a718b5d66e4.png">

3. 회원탈퇴 로직을 전부 통과한 경우
<img width="464" alt="탈퇴 성공" src="https://user-images.githubusercontent.com/113086103/221441232-c1dad8f3-1058-4b21-9ee5-de166adf7d7b.png">

![target, user 변경](https://user-images.githubusercontent.com/113086103/221441220-d46b9ad1-de8a-4561-908a-effc924f451e.png)
