### PR TITLE
feat(Funding): 타겟이 인플루언서(인기유저) 인 펀딩 조회

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/wishmarket/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .mvcMatchers(HttpMethod.OPTIONS, "/**").permitAll()
             .antMatchers("/api/auth/sign-up", "/api/auth/sign-in/**", "/api/auth/email-check",
                 "/api/auth/email-auth/**", "/api/user/password",
-                "/api/products/**", "/api/reviews/**", "/admin/**", "/api/auth/reissue").permitAll()
+                "/api/products/**", "/api/reviews/**", "/admin/**", "/api/auth/reissue","/api/funding/main").permitAll()
             .anyRequest().authenticated()
             .and()
             // logout 요청시 홈으로 이동 - 기본 logout url = "/logout"

--- a/src/main/java/com/zerobase/wishmarket/domain/funding/controller/FundingController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/controller/FundingController.java
@@ -64,6 +64,9 @@ public class FundingController {
 
     @GetMapping("/main")
     public ResponseEntity<List<FundingDetailResponse>> getFundingMain(@AuthenticationPrincipal Long userId){
+        if(userId == null){
+            return ResponseEntity.ok().body(fundingService.getFundingMain());
+        }
         return ResponseEntity.ok().body(fundingService.getFundingMain(userId));
     }
 

--- a/src/main/java/com/zerobase/wishmarket/domain/funding/controller/FundingController.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/controller/FundingController.java
@@ -11,8 +11,6 @@ import com.zerobase.wishmarket.domain.funding.model.form.FundingStartInputForm;
 import com.zerobase.wishmarket.domain.funding.service.FundingService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -62,6 +60,11 @@ public class FundingController {
     public ResponseEntity<FundingDetailResponse> getFundingDetail(@AuthenticationPrincipal Long userId,
         @PathVariable Long fundingId){
         return ResponseEntity.ok().body(fundingService.getFundingDetail(userId,fundingId));
+    }
+
+    @GetMapping("/main")
+    public ResponseEntity<List<FundingDetailResponse>> getFundingMain(@AuthenticationPrincipal Long userId){
+        return ResponseEntity.ok().body(fundingService.getFundingMain(userId));
     }
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/funding/model/dto/FundingDetailResponse.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/model/dto/FundingDetailResponse.java
@@ -22,7 +22,7 @@ public class FundingDetailResponse {
     private String targetUserName;
     private String targetUserProfileImageUrl;
     private Long targetPrice;
-    private Long fundedPrice;
+    private Long myFundedPrice;
     private Long totalFundedPrice;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
@@ -41,7 +41,7 @@ public class FundingDetailResponse {
             .targetUserName(funding.getTargetUser().getName())
             .targetUserProfileImageUrl(funding.getTargetUser().getProfileImage())
             .targetPrice(funding.getTargetPrice())
-            .fundedPrice(userFundedPrice)      //조회한 유저가 해당 펀딩에 펀딩을 했다면, 금액이 보여야 함
+            .myFundedPrice(userFundedPrice)      //조회한 유저가 해당 펀딩에 펀딩을 했다면, 금액이 보여야 함
             .totalFundedPrice(funding.getFundedPrice())
             .startDate(funding.getStartDate())
             .endDate(funding.getEndDate())

--- a/src/main/java/com/zerobase/wishmarket/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/repository/FundingRepository.java
@@ -11,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface FundingRepository extends JpaRepository<Funding, Long> {
 
     Page<Funding> findAllByTargetUser(UserEntity targetUser, Pageable pageable);
+
+    Funding findByTargetUser(UserEntity targetUser);
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/funding/service/FundingService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/service/FundingService.java
@@ -70,7 +70,7 @@ public class FundingService {
 
     private final AlarmService alarmService;
 
-    private final int FUNDING_NAMELISE_SIZE = 20;
+    private final int FUNDING_NAMELIST_SIZE = 20;
 
 
     @Transactional
@@ -324,7 +324,7 @@ public class FundingService {
 
             for (FundingParticipation p : funding.getParticipationList()) {
                 //참여자 이름은 20명까지만
-                if (participantsNameList.size() <= FUNDING_NAMELISE_SIZE) {
+                if (participantsNameList.size() <= FUNDING_NAMELIST_SIZE) {
                     participantsNameList.add(p.getUser().getName());
                 }
             }
@@ -391,7 +391,7 @@ public class FundingService {
 
         for (FundingParticipation p : funding.getParticipationList()) {
             //참여자 이름은 20명까지만
-            if (participantsNameList.size() <= FUNDING_NAMELISE_SIZE) {
+            if (participantsNameList.size() <= FUNDING_NAMELIST_SIZE) {
                 participantsNameList.add(p.getUser().getName());
             }
         }
@@ -400,7 +400,8 @@ public class FundingService {
 
     }
 
-    //메인 페이지, 인플루언서 타겟 펀딩 조회
+    //로그인한 경우
+    //메인 페이지, 인플루언서 타겟 펀딩 조회,
     //보여주기위함
     public List<FundingDetailResponse> getFundingMain(Long userId) {
 
@@ -409,8 +410,8 @@ public class FundingService {
 
         List<FundingDetailResponse> detailResponseList = new ArrayList<>();
 
-        //무작위 인기유저 목록
-        List<UserEntity> influenceUserList = userAuthRepository.findAllByInfluenceIsTrueRandom();
+        //무작위 인기유저 11명 목록
+        List<UserEntity> influenceUserList = userAuthRepository.findAllByInfluenceIsTrueRandomEleven();
 
         //인기유저가 타겟인 펀딩 목록
         List<Funding> influenceFundingList = new ArrayList<>();
@@ -438,7 +439,7 @@ public class FundingService {
 
             for (FundingParticipation p : funding.getParticipationList()) {
                 //참여자 이름은 20명까지만
-                if (participantsNameList.size() <= FUNDING_NAMELISE_SIZE) {
+                if (participantsNameList.size() <= FUNDING_NAMELIST_SIZE) {
                     participantsNameList.add(p.getUser().getName());
                 }
             }
@@ -448,5 +449,42 @@ public class FundingService {
 
         return detailResponseList;
     }
+
+    //로그인하지 않은 경우
+    //메인 페이지, 인플루언서 타겟 펀딩 조회,
+    //보여주기위함
+    public List<FundingDetailResponse> getFundingMain() {
+
+        List<FundingDetailResponse> detailResponseList = new ArrayList<>();
+
+        //무작위 인기유저 11명 목록
+        List<UserEntity> influenceUserList = userAuthRepository.findAllByInfluenceIsTrueRandomEleven();
+
+        //인기유저가 타겟인 펀딩 목록
+        List<Funding> influenceFundingList = new ArrayList<>();
+
+        //인기유저 펀딩이 무조건 존재한다고 가정
+        for(UserEntity influenceUser : influenceUserList){
+            influenceFundingList.add(fundingRepository.findByTargetUser(influenceUser));
+        }
+
+        for(Funding funding : influenceFundingList){
+
+            //해당 펀딩에 참여한 유저 이름 목록
+            List<String> participantsNameList = new ArrayList<>();
+
+            for (FundingParticipation p : funding.getParticipationList()) {
+                //참여자 이름은 20명까지만
+                if (participantsNameList.size() <= FUNDING_NAMELIST_SIZE) {
+                    participantsNameList.add(p.getUser().getName());
+                }
+            }
+
+            detailResponseList.add(FundingDetailResponse.from(funding, participantsNameList, 0L));
+        }
+
+        return detailResponseList;
+    }
+
 
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/funding/service/FundingService.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/funding/service/FundingService.java
@@ -34,6 +34,7 @@ import com.zerobase.wishmarket.domain.product.repository.ProductRepository;
 import com.zerobase.wishmarket.domain.product.repository.ReviewRepository;
 import com.zerobase.wishmarket.domain.user.exception.UserException;
 import com.zerobase.wishmarket.domain.user.model.entity.UserEntity;
+import com.zerobase.wishmarket.domain.user.repository.UserAuthRepository;
 import com.zerobase.wishmarket.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -42,9 +43,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,9 +64,13 @@ public class FundingService {
 
     private final OrderRepository orderRepository;
 
+    private final UserAuthRepository userAuthRepository;
+
     private final PointService pointService;
 
     private final AlarmService alarmService;
+
+    private final int FUNDING_NAMELISE_SIZE = 20;
 
 
     @Transactional
@@ -239,8 +242,9 @@ public class FundingService {
 
                     //금액 돌려주기
                     List<FundingParticipation> participationList = fundingFail.getParticipationList();
-                    for(FundingParticipation participation : participationList){
-                        pointService.refundPoint(participation.getUser().getUserId(),participation.getPrice());
+                    for (FundingParticipation participation : participationList) {
+                        pointService.refundPoint(participation.getUser().getUserId(),
+                            participation.getPrice());
                     }
                 });
         }
@@ -307,7 +311,6 @@ public class FundingService {
         UserEntity user = userRepository.findByUserId(userId)
             .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
-        int nameListSize = 20;
 
         List<FundingParticipation> participationList =
             fundingParticipationRepository.findAllByUser(user);
@@ -321,7 +324,7 @@ public class FundingService {
 
             for (FundingParticipation p : funding.getParticipationList()) {
                 //참여자 이름은 20명까지만
-                if (participantsNameList.size() <= nameListSize) {
+                if (participantsNameList.size() <= FUNDING_NAMELISE_SIZE) {
                     participantsNameList.add(p.getUser().getName());
                 }
             }
@@ -332,7 +335,7 @@ public class FundingService {
 
         return fundingListGiveResponses;
     }
-    
+
 
     public List<FundingMyGiftListResponse> getMyFundigGifyList(Long userId) {
         PageRequest pageRequest = PageRequest.of(0, 100);
@@ -375,27 +378,75 @@ public class FundingService {
             .orElseThrow(() -> new FundingException(FUNDING_NOT_FOUND));
 
         Long userFundedPrice = 0L;
-        int nameListSize = 20;
 
         //유저가 참여한 펀딩이라면 펀딩한 금액 표출, 아니라면 0원 표출
-        Optional<FundingParticipation> participation = fundingParticipationRepository.findByFundingAndUser(funding,user);
-        if(participation.isPresent()){
+        Optional<FundingParticipation> participation = fundingParticipationRepository.findByFundingAndUser(
+            funding, user);
+        if (participation.isPresent()) {
             userFundedPrice = participation.get().getPrice();
         }
 
         //해당 펀딩에 참여한 유저 이름 목록
         List<String> participantsNameList = new ArrayList<>();
 
-        for(FundingParticipation p : funding.getParticipationList()){
+        for (FundingParticipation p : funding.getParticipationList()) {
             //참여자 이름은 20명까지만
-            if(participantsNameList.size() <= nameListSize) {
+            if (participantsNameList.size() <= FUNDING_NAMELISE_SIZE) {
                 participantsNameList.add(p.getUser().getName());
             }
         }
 
+        return FundingDetailResponse.from(funding, participantsNameList, userFundedPrice);
 
-        return FundingDetailResponse.from(funding,participantsNameList,userFundedPrice);
+    }
 
+    //메인 페이지, 인플루언서 타겟 펀딩 조회
+    //보여주기위함
+    public List<FundingDetailResponse> getFundingMain(Long userId) {
+
+        UserEntity user = userRepository.findByUserId(userId)
+            .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+
+        List<FundingDetailResponse> detailResponseList = new ArrayList<>();
+
+        //무작위 인기유저 목록
+        List<UserEntity> influenceUserList = userAuthRepository.findAllByInfluenceIsTrueRandom();
+
+        //인기유저가 타겟인 펀딩 목록
+        List<Funding> influenceFundingList = new ArrayList<>();
+
+        //인기유저 펀딩이 무조건 존재한다고 가정
+        for(UserEntity influenceUser : influenceUserList){
+            influenceFundingList.add(fundingRepository.findByTargetUser(influenceUser));
+        }
+
+        for(Funding funding : influenceFundingList){
+
+            //유저가 참여한 금액
+            Long userFundedPrice = 0L;
+
+            //유저가 참여한 펀딩이라면 펀딩한 금액 표출, 아니라면 0원 표출
+            Optional<FundingParticipation> participation = fundingParticipationRepository.findByFundingAndUser(
+                funding, user);
+            if (participation.isPresent()) {
+                userFundedPrice = participation.get().getPrice();
+            }
+
+
+            //해당 펀딩에 참여한 유저 이름 목록
+            List<String> participantsNameList = new ArrayList<>();
+
+            for (FundingParticipation p : funding.getParticipationList()) {
+                //참여자 이름은 20명까지만
+                if (participantsNameList.size() <= FUNDING_NAMELISE_SIZE) {
+                    participantsNameList.add(p.getUser().getName());
+                }
+            }
+
+            detailResponseList.add(FundingDetailResponse.from(funding, participantsNameList, userFundedPrice));
+        }
+
+        return detailResponseList;
     }
 
 }


### PR DESCRIPTION
## 변경사항


메인 페이지에서 노출할

타겟이 인기유저인 펀딩조회 API 입니다.

인기유저 무작위 4명을 취합해,
4명이 타겟인 펀딩의 상세정보 목록을 보여줍니다.

상세정보 목록사이즈도 4입니다.

접속한 유저가 해당 펀딩에 참여했다면, 참여한 금액도 상세정보에 포함시켜 보여줍니다.

현재 단계에선 보여주기 위함으로 정교한 기능을 위해선
수정이 필요합니다.

===========================================================================
1. FundingDetailResponse fundedPrice를 의미를 명확히 하기 위해

myFundedPrice로 수정하였습니다.

2. 메인페이지에 표출할 펀딩 목록 사이즈와 참여한 유저목록 사이즈를 전역변수로 관리하도록 수정하였습니다.

3. 타겟이 인기유저인 펀딩조회 API를 추가하였습니다.



## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?


![image](https://user-images.githubusercontent.com/79897135/222069333-192cb7cc-250a-4dec-a8b4-bc12de972075.png)
