### PR TITLE
fix(User) : 회원정보 수정기능 변경

### DIFF
--- a/src/main/java/com/zerobase/wishmarket/controller/UserController.java
+++ b/src/main/java/com/zerobase/wishmarket/controller/UserController.java
@@ -1,22 +1,18 @@
 package com.zerobase.wishmarket.controller;
 
 
+import com.zerobase.wishmarket.domain.user.model.dto.UserInfoResponse;
 import com.zerobase.wishmarket.domain.user.model.form.ChangePwdForm;
 import com.zerobase.wishmarket.domain.user.model.form.UpdateForm;
-import com.zerobase.wishmarket.domain.user.model.dto.UserInfoResponse;
 import com.zerobase.wishmarket.domain.user.model.type.UserPasswordChangeReturnType;
 import com.zerobase.wishmarket.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/user")
@@ -36,8 +32,13 @@ public class UserController {
         return ResponseEntity.ok(userService.passwordChange(form));
     }
 
-    @PatchMapping("/update")
-    public ResponseEntity<UserInfoResponse> userInfoUpdate(@AuthenticationPrincipal Long userId, UpdateForm form) {
-        return ResponseEntity.ok(userService.userInfoUpdate(userId, form));
+    @PatchMapping("/updateUserInfo")
+    public ResponseEntity<UserInfoResponse> updateUserInfo(@AuthenticationPrincipal Long userId, UpdateForm form) {
+        return ResponseEntity.ok(userService.updateUserInfo(userId, form));
+    }
+
+    @PatchMapping("/updateUserProfileImage")
+    public ResponseEntity<UserInfoResponse> updateUserProfileImage(@AuthenticationPrincipal Long userId, MultipartFile profileImage) {
+        return ResponseEntity.ok(userService.updateUserProfileImage(userId, profileImage));
     }
 }

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/UserInfoResponse.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/dto/UserInfoResponse.java
@@ -7,7 +7,6 @@ import com.zerobase.wishmarket.domain.user.model.type.UserStatusType;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Getter
 @Builder
@@ -22,7 +21,7 @@ public class UserInfoResponse {
     private String nickName;
     private String phone;
     private Long pointPrice;
-    private String profileImage;
+    private String profileImageUrl;
     private String address;
     private String detailAddress;
     private UserRegistrationType userRegistrationType;
@@ -50,7 +49,7 @@ public class UserInfoResponse {
                 .pointPrice(userEntity.getPointPrice())
                 .address("")
                 .detailAddress("")
-                .profileImage(userEntity.getProfileImage())
+                .profileImageUrl(userEntity.getProfileImage())
                 .userRegistrationType(userEntity.getUserRegistrationType())
                 .userStatusType(userEntity.getUserStatusType())
                 .userRolesType(userEntity.getUserRoleType())

--- a/src/main/java/com/zerobase/wishmarket/domain/user/model/form/UpdateForm.java
+++ b/src/main/java/com/zerobase/wishmarket/domain/user/model/form/UpdateForm.java
@@ -14,5 +14,4 @@ public class UpdateForm {
     private String detailAddress;
 
     private String phone;
-    private MultipartFile profileImage;
 }


### PR DESCRIPTION
## 관련이슈
- #147 

## 변경사항
- 기존 : 회원정보 수정 시 프로필 이미지, 닉네임, 주소, 연락처 를 form 으로 전달받아 수정
- 변경 : 프로필 이미지 수정 API 별도 구현으로 기존 form 으로는 닉네임, 주소, 연락처만 수정하도록 변경

## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [X]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [X]  모든 **테스트**가 성공했나요?

## 테스트 결과
<img width="762" alt="스크린샷 2023-03-05 오후 5 14 16" src="https://user-images.githubusercontent.com/113086103/222950312-8a4d49f4-fbbe-47ab-9d21-cd0e00ca4e9a.png">
<img width="806" alt="스크린샷 2023-03-05 오후 5 17 16" src="https://user-images.githubusercontent.com/113086103/222950321-0d8e2d99-06fa-4407-ae56-d90b45785282.png">
